### PR TITLE
Modernize responsive Konfigurator layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AST31-Konfigurator</title>
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/svg+xml" href="favicon.png">

--- a/style.css
+++ b/style.css
@@ -1,111 +1,229 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --background: #eef2f9;
+  --background-alt: #dfe6f5;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-strong: rgba(255, 255, 255, 0.98);
+  --text-primary: #1f2a3d;
+  --text-muted: #5d6778;
+  --accent: #2f6df6;
+  --accent-strong: #1c4bd8;
+  --accent-soft: rgba(47, 109, 246, 0.16);
+  --border-subtle: rgba(31, 42, 61, 0.12);
+  --shadow-strong: 0 25px 70px rgba(20, 35, 85, 0.18);
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --logo-width: clamp(180px, 18vw, 260px);
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: linear-gradient(145deg, var(--background), var(--background-alt));
+  padding: clamp(120px, 12vw, 180px) clamp(18px, 3vw, 60px) clamp(48px, 6vw, 96px);
+  -webkit-font-smoothing: antialiased;
 }
 
 .app {
-  display: flex;
-  height: 100vh;
+  width: min(1280px, 100%);
+  min-height: min(82vh, 880px);
+  margin: 0 auto;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(14px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) clamp(280px, 24vw, 360px);
+  overflow: hidden;
 }
 
-#preview { touch-action: none; }
-
-
-/* --- Preview-Bereich --- */
 #preview {
-  flex: 1;
-  display: flex;
-  align-items: flex-start;   /* oben ausrichten */
-  justify-content: center;   /* horizontal zentrieren */
-  background: #f9f9f9;
-  border-right: 1px solid #ccc;
   position: relative;
-  overflow: hidden;          /* nichts läuft über */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(180deg, rgba(47, 109, 246, 0.08) 0%, rgba(47, 109, 246, 0.02) 100%), var(--surface-strong);
+  padding: clamp(24px, 4vw, 48px);
+  overflow: hidden;
+  touch-action: none;
 }
 
-/* Bühne (Zoom-Canvas) – echte Höhe via aspect-ratio statt fixer Pixel */
 #stage {
   position: relative;
-  width: min(100%, 1200px);  /* Basisbreite, responsiv begrenzt */
-  aspect-ratio: 12 / 7;      /* entspricht z.B. 1200×700 */
-  transform-origin: top left;/* Offsets bleiben stabil beim Zoom */
+  width: min(100%, 1180px);
+  aspect-ratio: 12 / 7;
+  background: #fff;
+  border-radius: 20px;
+  border: 1px solid var(--border-subtle);
+  box-shadow: 0 20px 45px rgba(15, 26, 58, 0.18);
+  overflow: hidden;
+  transform-origin: top left;
   will-change: transform;
 }
 
-/* Bilder hängen jetzt unter #stage */
 #stage img {
   position: absolute;
   opacity: 0;
-  transition: opacity 0.4s ease-in-out;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  transform: translateZ(0);
 }
 
-#stage img.show { opacity: 1; }
+#stage img.show {
+  opacity: 1;
+}
 
-
-/* --- Sidebar allgemein --- */
 .sidebar {
-  width: 250px;
-  border-left: 1px solid #ccc;
-  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0.82) 100%);
+  border-left: 1px solid var(--border-subtle);
+  padding: clamp(22px, 3vw, 34px);
+  gap: clamp(18px, 2vw, 28px);
+  overflow: hidden;
 }
 
 .sidebar-controls {
-  margin-bottom: 10px;
+  position: sticky;
+  top: 0;
+  padding-bottom: 16px;
+  margin-bottom: 4px;
+  background: inherit;
+  z-index: 2;
+  box-shadow: 0 1px 0 var(--border-subtle);
+}
+
+#sidebarContent {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+  margin-right: -6px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#sidebarContent::-webkit-scrollbar {
+  width: 6px;
+}
+
+#sidebarContent::-webkit-scrollbar-thumb {
+  background: var(--accent);
+  border-radius: 999px;
+}
+
+button,
+select,
+input {
+  font: inherit;
+  color: inherit;
 }
 
 .article-overlay-toggle {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  background: #f1f1f1;
-  font-size: 0.95em;
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 22px rgba(47, 109, 246, 0.25);
 }
 
 .article-overlay-toggle:hover,
-.article-overlay-toggle:focus {
-  background: #e4e4e4;
+.article-overlay-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(47, 109, 246, 0.32);
 }
 
-/* --- Groups (Hauptblöcke) --- */
+.article-overlay-toggle:focus-visible {
+  outline: none;
+}
+
 .group > h1 {
-  font-size: 1.1em;
-  margin: 10px 0;
-  padding: 5px;
-  background: #dde;
-  cursor: pointer;
+  font-size: 1.05rem;
+  margin: 0;
+  padding: 12px 18px 12px 48px;
+  border-radius: var(--radius-md);
+  background: rgba(47, 109, 246, 0.08);
+  color: var(--text-primary);
   position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
-/* Plus/Minus für Gruppen */
+.group > h1:hover {
+  background: rgba(47, 109, 246, 0.14);
+}
+
 .group > h1::before {
   content: "+";
-  font-weight: bold;
-  margin-right: 5px;
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: #fff;
+  color: var(--accent);
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 4px 12px rgba(47, 109, 246, 0.18);
 }
 
 .group:not(.collapsed) > h1::before {
   content: "−";
 }
 
-/* --- Sections (Unterpunkte) --- */
-.section h2 {
-  font-size: 1em;
-  background: #eee;
-  margin: 0;
-  padding: 6px 6px 6px 24px; /* Platz für + / - */
-  cursor: pointer;
-  position: relative;
+.section {
+  background: rgba(31, 42, 61, 0.04);
+  border-radius: 14px;
+  overflow: hidden;
 }
 
-/* Plus/Minus für Sections */
+.section h2 {
+  font-size: 0.95rem;
+  margin: 0;
+  padding: 12px 18px 12px 52px;
+  background: rgba(31, 42, 61, 0.05);
+  cursor: pointer;
+  position: relative;
+  color: var(--text-primary);
+  transition: background 0.2s ease;
+}
+
 .section h2::before {
   content: "−";
   position: absolute;
-  left: 8px;
-  font-weight: bold;
+  left: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #fff;
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  box-shadow: 0 3px 8px rgba(47, 109, 246, 0.12);
+}
+
+.section.collapsed h2 {
+  background: rgba(31, 42, 61, 0.035);
 }
 
 .section.collapsed h2::before {
@@ -113,26 +231,35 @@ body {
 }
 
 .section .content {
-  padding: 8px;
+  padding: 14px 18px 18px;
 }
 
 .section.collapsed .content {
   display: none;
 }
 
-/* Wenn die ganze Gruppe collapsed ist → alle Sections darin auch einklappen */
-.group.collapsed .section {
-  display: none;
-}
-
-
-/* --- Select-Elemente --- */
 select {
   width: 100%;
-  margin: 5px 0 15px 0;
+  margin: 6px 0 16px;
+  padding: 12px 42px 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%232f6df6' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/%3E%3C/svg%3E") no-repeat right 16px center / 12px;
+  color: var(--text-primary);
+  appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-/* --- Artikelliste --- */
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  outline: none;
+}
+
+select:disabled {
+  background-color: rgba(31, 42, 61, 0.06);
+  color: var(--text-muted);
+}
 
 #articleItems {
   list-style: none;
@@ -141,21 +268,27 @@ select {
 }
 
 #articleItems li {
-  padding: 6px 4px;
-  border-bottom: 1px solid #eee;
-  font-size: 14px;
+  border-bottom: 1px solid rgba(31, 42, 61, 0.08);
+}
+
+#articleItems li:last-child {
+  border-bottom: none;
 }
 
 #articleItems li a.article-link {
   display: block;
-  padding: 6px 4px;
+  padding: 12px 14px;
   text-decoration: none;
   color: inherit;
-  border-radius: 6px;
+  border-radius: 12px;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-#articleItems li a.article-link:hover {
-  background: #f2f2f2;
+#articleItems li a.article-link:hover,
+#articleItems li a.article-link:focus-visible {
+  background: rgba(47, 109, 246, 0.12);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .article-overlay {
@@ -164,8 +297,8 @@ select {
   display: none;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.4);
-  padding: 20px;
+  background: rgba(15, 23, 42, 0.45);
+  padding: clamp(20px, 6vw, 48px);
   z-index: 1500;
 }
 
@@ -175,94 +308,195 @@ select {
 
 .article-overlay__panel {
   background: #fff;
-  width: min(420px, 100%);
-  max-height: 90vh;
-  border-radius: 10px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  padding: 24px 24px 16px 24px;
+  width: min(480px, 100%);
+  max-height: min(90vh, 680px);
+  border-radius: 20px;
+  box-shadow: var(--shadow-strong);
+  padding: 28px 28px 20px;
   display: flex;
   flex-direction: column;
   position: relative;
 }
 
 .article-overlay__panel h2 {
-  margin: 0 0 16px 0;
+  margin: 0 0 18px 0;
+  font-size: 1.35rem;
 }
 
 .article-overlay__close {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 16px;
+  right: 16px;
   border: none;
   background: transparent;
-  font-size: 1.5rem;
+  font-size: 1.7rem;
   line-height: 1;
   cursor: pointer;
+  color: var(--text-muted);
+  transition: color 0.2s ease;
 }
 
 .article-overlay__close:hover,
-.article-overlay__close:focus {
-  color: #444;
+.article-overlay__close:focus-visible {
+  color: var(--accent);
+  outline: none;
 }
 
 .article-overlay__panel #articleItems {
   overflow-y: auto;
   flex: 1;
+  padding-right: 4px;
 }
-
 
 #articleItems .code {
-  color: #555;
-  font-size: 13px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
 }
 
-/* --- Teilen-Link --- */
 .share-container {
   display: flex;
-  gap: 5px;
+  gap: 10px;
   align-items: center;
+  margin-top: 12px;
 }
 
 #shareInput {
   flex: 1;
-  padding: 4px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 0.9em;
+  padding: 10px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.92);
 }
 
 #copyBtn {
   cursor: pointer;
-  background: #eee;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 4px 8px;
-  font-size: 1em;
-  transition: background 0.2s;
+  background: rgba(47, 109, 246, 0.12);
+  border: 1px solid transparent;
+  color: var(--accent-strong);
+  border-radius: 12px;
+  padding: 10px 16px;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-#copyBtn:hover {
-  background: #ddd;
-}
-
-/* --- Logo oben links --- */
-:root {
-  --logo-width: 300px;   /* Breite ändern */
-  --logo-margin: 10px;   /* äußerer Abstand */
-  --logo-padding: 0px;   /* innerer Abstand */
+#copyBtn:hover,
+#copyBtn:focus-visible {
+  background: rgba(47, 109, 246, 0.2);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 #logo-container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  margin: var(--logo-margin);
-  padding: var(--logo-padding);
-  z-index: 1000; /* Immer über dem Rest */
+  position: fixed;
+  top: clamp(18px, 4vw, 32px);
+  left: clamp(18px, 4vw, 40px);
+  margin: 0;
+  padding: 12px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 18px 46px rgba(20, 35, 85, 0.2);
+  backdrop-filter: blur(12px);
+  z-index: 1000;
 }
 
 #logo-container img {
   width: var(--logo-width);
   height: auto;
   display: block;
+}
+
+@media (max-width: 1100px) {
+  .app {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: auto;
+  }
+
+  #preview {
+    min-height: clamp(360px, 50vh, 520px);
+  }
+
+  .sidebar {
+    border-left: none;
+    border-top: 1px solid var(--border-subtle);
+    padding: 24px;
+  }
+
+  .sidebar-controls {
+    position: static;
+    padding-bottom: 0;
+    margin-bottom: 0;
+    box-shadow: none;
+  }
+
+  #sidebarContent {
+    overflow-y: visible;
+    margin-right: 0;
+    padding-right: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 32px 18px 42px;
+  }
+
+  #logo-container {
+    position: static;
+    margin: 0 auto 24px;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+    display: flex;
+    justify-content: center;
+  }
+
+  #logo-container img {
+    width: clamp(160px, 48vw, 220px);
+  }
+
+  .app {
+    border-radius: 18px;
+    box-shadow: 0 18px 40px rgba(20, 35, 85, 0.15);
+  }
+}
+
+@media (max-width: 600px) {
+  #preview {
+    padding: 20px;
+  }
+
+  #stage {
+    border-radius: 16px;
+  }
+
+  .sidebar {
+    padding: 20px;
+    gap: 18px;
+  }
+
+  .section .content {
+    padding: 12px 12px 16px;
+  }
+
+  .article-overlay__panel {
+    padding: 24px 20px 18px;
+    border-radius: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary
- add a viewport meta tag to enable responsive behaviour on mobile devices
- restyle the configurator shell with modern colours, spacing and component treatments
- improve sidebar, overlay and logo behaviour so the layout adapts smoothly on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9c4bf08c8832b80754d7b78f0e185