### PR TITLE
Fix mobile preview scaling and sidebar collapse

### DIFF
--- a/js/imageManager.js
+++ b/js/imageManager.js
@@ -19,15 +19,22 @@ export function fadeIn(img, src) {
   };
 }
 
-export function placeImage(img, src, cfg) {
+export function placeImage(img, src, cfg, stageScale = 1) {
   if (!cfg) {
     img.style.display = "none";
     return;
   }
+
+  const effectiveScale = Number.isFinite(stageScale) && stageScale > 0 ? stageScale : 1;
+  const scaledX = (cfg.x ?? 0) * effectiveScale;
+  const scaledY = (cfg.y ?? 0) * effectiveScale;
+  const scaledScaleX = (cfg.scaleX ?? 1) * effectiveScale;
+  const scaledScaleY = (cfg.scaleY ?? 1) * effectiveScale;
+
   fadeIn(img, src);
-  img.style.left = cfg.x + "px";
-  img.style.top = cfg.y + "px";
-  img.style.transform = `scale(${cfg.scaleX}, ${cfg.scaleY})`;
+  img.style.left = `${scaledX}px`;
+  img.style.top = `${scaledY}px`;
+  img.style.transform = `scale(${scaledScaleX}, ${scaledScaleY})`;
   img.style.transformOrigin = "top left";
   img.style.display = "block";
 }

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,8 @@ import { initPreviewZoom } from "./zoom.js";
 
 let configXML;
 const images = {};
+let resizeTimeoutId;
+const RESIZE_DEBOUNCE = 150;
 
 /**
  * Liest ?config=… aus der URL, decodiert die Werte und schreibt sie in die Selects.
@@ -56,6 +58,11 @@ async function init() {
 
   // 6) Erste Darstellung
   updatePreview(configXML, images);
+
+  window.addEventListener("resize", () => {
+    window.clearTimeout(resizeTimeoutId);
+    resizeTimeoutId = window.setTimeout(() => updatePreview(configXML, images), RESIZE_DEBOUNCE);
+  });
 }
 
 function setupArticleOverlay() {

--- a/js/preview.js
+++ b/js/preview.js
@@ -4,12 +4,24 @@ import { placeImage } from "./imageManager.js";
 import { renderArticleList } from "./articles.js";
 import { updateURL } from "./share.js";
 
+const BASE_STAGE_WIDTH = 1180;
+
 export function updatePreview(configXML, images) {
   const values = {};
   document.querySelectorAll(".sidebar select").forEach(sel => values[sel.id] = sel.value);
 
+  const stageEl = document.getElementById("stage");
+  let stageScale = 1;
+  if (stageEl) {
+    const rect = stageEl.getBoundingClientRect();
+    const width = rect.width || stageEl.clientWidth;
+    if (width) {
+      stageScale = Math.max(width / BASE_STAGE_WIDTH, 0.1);
+    }
+  }
+
   // --- Spezial-Logik für AST31-EL ---
-  	applyAst31Logic(values);
+        applyAst31Logic(values);
 
   // --- Logik für Böden + Platten ---
   	applyBodenPlattenLogic(values);
@@ -97,11 +109,11 @@ export function updatePreview(configXML, images) {
     }
 
     // --- Bild anzeigen ---
-    placeImage(images[id], `bilder/${folder}/${key}.png`, cfg);
+    placeImage(images[id], `bilder/${folder}/${key}.png`, cfg, stageScale);
 
 
     // Sonderfall: Container rechts → Bild spiegeln
-	if (id === "containerRechts") {
+        if (id === "containerRechts") {
   	images[id].style.transform += " scaleX(-1)";
 	}
   });

--- a/style.css
+++ b/style.css
@@ -163,6 +163,10 @@ input {
   transition: background 0.2s ease, color 0.2s ease;
 }
 
+.group.collapsed .section {
+  display: none;
+}
+
 .group > h1:hover {
   background: rgba(47, 109, 246, 0.14);
 }


### PR DESCRIPTION
## Summary
- scale layer positioning by the current stage width so the preview renders on narrow screens
- update the preview on window resize to keep image alignment correct after orientation changes
- hide collapsed sidebar groups so the accordion behaves as expected on mobile

## Testing
- Manual mobile verification in Chromium (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68c9d1140e24832bb143fac68af9eba9