### PR TITLE
Fix missing Laufschienen and Unterbau layers

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -153,25 +153,22 @@
     <!-- Laufschienen -->
     <layer id="laufschiene1" folder="laufschienen" keyPattern="laufschiene-{breite}" dependsOn="aufbau:hoch,laufschienenanzahl:1|2" offsetGroup="laufschienenOffsets"/>
     <layer id="laufschiene2" folder="laufschienen" keyPattern="laufschiene-{breite}" dependsOn="aufbau:hoch,laufschienenanzahl:2" offsetGroup="laufschienenOffsets"/>
-  </layers>
- <layer
-  id="ablagebord"
-  folder="ablagebord"
-  keyPattern="ablagebord-{ablagebord}-{breite}"
-  dependsOn="gestell:ast31,ablagebord:buche|weiss"
-  offsetGroup="ablagebordOffsets"
-/>
-
+    <layer id="ablagebord"
+           folder="ablagebord"
+           keyPattern="ablagebord-{ablagebord}-{breite}"
+           dependsOn="gestell:ast31,ablagebord:buche|weiss"
+           offsetGroup="ablagebordOffsets"/>
     <layer id="containerLinks"
-         folder="container"
-         keyPattern="container-{farbe}-{containerfarbe}-{breite}"
-         dependsOn="containerpos:links|links-rechts"
-         offsetGroup="containerOffsets" />
-  <layer id="containerRechts"
-         folder="container"
-         keyPattern="container-{farbe}-{containerfarbe}-{breite}"
-         dependsOn="containerpos:rechts|links-rechts"
-         offsetGroup="containerOffsets" />
+           folder="container"
+           keyPattern="container-{farbe}-{containerfarbe}-{breite}"
+           dependsOn="containerpos:links|links-rechts"
+           offsetGroup="containerOffsets"/>
+    <layer id="containerRechts"
+           folder="container"
+           keyPattern="container-{farbe}-{containerfarbe}-{breite}"
+           dependsOn="containerpos:rechts|links-rechts"
+           offsetGroup="containerOffsets"/>
+  </layers>
 
   <offsets>
     <grundtische>

--- a/js/preview.js
+++ b/js/preview.js
@@ -87,6 +87,8 @@ export function updatePreview(configXML, images) {
     if (offsetGroup) {
       if (targetId.startsWith("boden") || targetId.startsWith("platte")) {
         cfg = parseOffset(configXML, `offsets > ${offsetGroup} > item[id="${targetId}-${values.breite}"]`);
+      } else if (targetId.startsWith("laufschiene")) {
+        cfg = parseOffset(configXML, `offsets > ${offsetGroup} > item[id="${targetId}-${values.breite}"]`);
       } else if (targetId === "seitenLinks" || targetId === "seitenRechts" ||
                  targetId === "containerLinks" || targetId === "containerRechts") {
         const side = targetId.endsWith("Links") ? "left" : "right";


### PR DESCRIPTION
## Summary
- move the ablagebord and container definitions inside the shared <layers> block so they are processed
- adjust the preview offset lookup to resolve Laufschienen layer positions from the correct offset entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca5f55d27c832b926aca4ebdf9dc5e