### PR TITLE
Add modal overlay for article list and share controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,18 +18,46 @@
     <div id="preview">
       <div id="stage"></div>
     </div>
-    <!-- Artikelliste -->
-  <div class="sidebar" id="article-list">
-    <div class="section">
-      <h2>Artikelliste</h2>
-      <div class="content">
-        <ul id="articleItems"></ul>
-      </div>
+    <div class="sidebar-container">
+      <button
+        id="articleListTrigger"
+        class="btn overlay-trigger"
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-controls="articleOverlay"
+      >
+        Artikelliste &amp; Teilen
+      </button>
+      <div class="sidebar" id="sidebar"></div>
     </div>
   </div>
 
-  <!-- Konfigurator -->
-    <div class="sidebar" id="sidebar"></div>
+  <div id="articleOverlay" class="article-overlay" aria-hidden="true">
+    <div
+      class="article-overlay__dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="articleOverlayTitle"
+    >
+      <header class="article-overlay__header">
+        <h2 id="articleOverlayTitle">Artikelliste</h2>
+        <button
+          type="button"
+          class="btn btn--icon article-overlay__close"
+          data-overlay-close
+          aria-label="Artikelliste schließen"
+        >
+          ✕
+        </button>
+      </header>
+      <div class="article-overlay__body">
+        <div class="article-overlay__list-wrapper">
+          <ul id="articleItems" class="article-overlay__list"></ul>
+        </div>
+        <div id="articleOverlayShare" class="article-overlay__share"></div>
+      </div>
+    </div>
   </div>
 
   <!-- Einstiegspunkt ins modulare Setup -->

--- a/js/articles.js
+++ b/js/articles.js
@@ -93,20 +93,28 @@ if (values.ablagebord && values.ablagebord !== "ohne") {
   }
 }
 
-// --- Rendern (Listenelemente klickbar) ---
-const BASE = "https://www.schaefer-shop.de/product/search?query=";
+  // --- Rendern (Listenelemente klickbar) ---
+  const BASE = "https://www.schaefer-shop.de/product/search?query=";
 
-items.forEach(item => {
-  const li = document.createElement("li");
+  if (items.length === 0) {
+    const empty = document.createElement("li");
+    empty.className = "article-overlay__empty";
+    empty.textContent = "Keine Artikeldaten verfügbar.";
+    list.appendChild(empty);
+    return;
+  }
 
-  const a = document.createElement("a");
-  a.className = "article-link";
-  a.href = BASE + encodeURIComponent(item.code);
-  a.target = "_blank";
-  a.rel = "noopener noreferrer";
-  a.innerHTML = `<strong>${item.label}</strong><br><span class="code">${item.code}</span>`;
+  items.forEach(item => {
+    const li = document.createElement("li");
 
-  li.appendChild(a);
-  list.appendChild(li);
-});
+    const a = document.createElement("a");
+    a.className = "article-link";
+    a.href = BASE + encodeURIComponent(item.code);
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.innerHTML = `<strong>${item.label}</strong><br><span class="code">${item.code}</span>`;
+
+    li.appendChild(a);
+    list.appendChild(li);
+  });
 }

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,63 @@ import { initPreviewZoom } from "./zoom.js";
 
 let configXML;
 const images = {};
+function setupArticleOverlay() {
+  const overlay = document.getElementById("articleOverlay");
+  const trigger = document.getElementById("articleListTrigger");
+  if (!overlay || !trigger) return;
+
+  const closeButton = overlay.querySelector("[data-overlay-close]");
+  let lastFocusedElement = null;
+
+  const openOverlay = () => {
+    if (overlay.classList.contains("is-open")) return;
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    overlay.classList.add("is-open");
+    overlay.setAttribute("aria-hidden", "false");
+    document.body.classList.add("overlay-open");
+    trigger.setAttribute("aria-expanded", "true");
+    if (closeButton instanceof HTMLElement) {
+      closeButton.focus();
+    }
+  };
+
+  const closeOverlay = () => {
+    if (!overlay.classList.contains("is-open")) return;
+    overlay.classList.remove("is-open");
+    overlay.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("overlay-open");
+    trigger.setAttribute("aria-expanded", "false");
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    } else {
+      trigger.focus();
+    }
+    lastFocusedElement = null;
+  };
+
+  trigger.addEventListener("click", openOverlay);
+
+  if (closeButton instanceof HTMLElement) {
+    closeButton.addEventListener("click", closeOverlay);
+  }
+
+  overlay.addEventListener("click", (event) => {
+    const target = event.target;
+    if (target === overlay) {
+      closeOverlay();
+    }
+    if (target instanceof HTMLElement && target.dataset.overlayClose !== undefined) {
+      closeOverlay();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && overlay.classList.contains("is-open")) {
+      event.preventDefault();
+      closeOverlay();
+    }
+  });
+}
 
 /**
  * Liest ?config=… aus der URL, decodiert die Werte und schreibt sie in die Selects.
@@ -27,6 +84,8 @@ function loadFromURL() {
 }
 
 async function init() {
+  setupArticleOverlay();
+
   // 1) Konfiguration & Artikelliste laden
   configXML = await loadConfig();
   await loadArticles();

--- a/js/share.js
+++ b/js/share.js
@@ -42,36 +42,43 @@ export function updateURL(values) {
   const newURL = `${window.location.pathname}?${params.toString()}`;
   window.history.replaceState({}, "", newURL);
 
-  let linkBox = document.getElementById("share-link");
-  if (!linkBox) {
-    linkBox = document.createElement("div");
-    linkBox.id = "share-link";
-    linkBox.className = "section";
-    linkBox.innerHTML = `
-      <h2>Teilen</h2>
-      <div class="content">
-        <div class="share-container">
-          <input type="text" id="shareInput" readonly>
-          <button id="copyBtn" title="Kopieren">📋</button>
-        </div>
+  const shareRoot = document.getElementById("articleOverlayShare");
+  if (!shareRoot) return;
+
+  if (!shareRoot.querySelector("#shareInput")) {
+    shareRoot.innerHTML = `
+      <h3>Konfiguration teilen</h3>
+      <div class="share-container">
+        <input type="text" id="shareInput" readonly>
+        <button id="copyBtn" class="btn btn--icon" type="button" title="Kopieren">📋</button>
       </div>
     `;
-    document.getElementById("article-list").appendChild(linkBox);
 
-    // Copy-Logik
-    linkBox.querySelector("#copyBtn").addEventListener("click", () => {
-      const input = document.getElementById("shareInput");
+    const copyBtn = shareRoot.querySelector("#copyBtn");
+    copyBtn.addEventListener("click", async () => {
+      const input = shareRoot.querySelector("#shareInput");
+      input.focus();
       input.select();
-      document.execCommand("copy");
-      // kleines Feedback
-      const oldText = linkBox.querySelector("#copyBtn").textContent;
-      linkBox.querySelector("#copyBtn").textContent = "✅";
+      input.setSelectionRange(0, input.value.length);
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(input.value);
+        } else {
+          document.execCommand("copy");
+        }
+      } catch (err) {
+        document.execCommand("copy");
+      }
+
+      const oldText = copyBtn.textContent;
+      copyBtn.textContent = "✅";
+      copyBtn.focus();
       setTimeout(() => {
-        linkBox.querySelector("#copyBtn").textContent = oldText;
+        copyBtn.textContent = oldText;
       }, 1000);
     });
   }
 
-  // URL ins Input schreiben
-  linkBox.querySelector("#shareInput").value = window.location.origin + newURL;
+  shareRoot.querySelector("#shareInput").value = window.location.origin + newURL;
 }

--- a/style.css
+++ b/style.css
@@ -3,9 +3,46 @@ body {
   font-family: Arial, sans-serif;
 }
 
+body.overlay-open {
+  overflow: hidden;
+}
+
 .app {
   display: flex;
   height: 100vh;
+}
+
+button {
+  font-family: inherit;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 8px 12px;
+  border: 1px solid #c0c0c0;
+  border-radius: 6px;
+  background: linear-gradient(#f8f8f8, #e4e4e4);
+  color: #222;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  background: linear-gradient(#ffffff, #ebebeb);
+  border-color: #a5a5a5;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
+}
+
+.btn--icon {
+  padding: 6px;
+  min-width: 40px;
 }
 
 #preview { touch-action: none; }
@@ -43,10 +80,30 @@ body {
 
 
 /* --- Sidebar allgemein --- */
-.sidebar {
+.sidebar-container {
   width: 250px;
+  display: flex;
+  flex-direction: column;
   border-left: 1px solid #ccc;
+  background: #fff;
+  min-height: 0;
+}
+
+#articleListTrigger {
+  margin: 16px 10px 10px;
+  align-self: stretch;
+  position: sticky;
+  top: 16px;
+  z-index: 1;
+  font-weight: 600;
+  text-align: center;
+}
+
+.sidebar {
+  flex: 1;
   padding: 10px;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 /* --- Groups (Hauptblöcke) --- */
@@ -112,90 +169,145 @@ select {
   margin: 5px 0 15px 0;
 }
 
-/* --- Artikelliste --- */
-.article-list {
-  width: 220px;
-  border-left: 1px solid #ccc;
-  border-right: 1px solid #ccc;
-  padding: 10px;
-  background: #fafafa;
+/* --- Artikelliste Overlay --- */
+.article-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1500;
+}
+
+.article-overlay.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.article-overlay__dialog {
+  background: #fff;
+  border-radius: 12px;
+  width: min(90vw, 520px);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  transform: translateY(12px);
+  transition: transform 0.2s ease;
+}
+
+.article-overlay.is-open .article-overlay__dialog {
+  transform: translateY(0);
+}
+
+.article-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 22px;
+  border-bottom: 1px solid #eee;
+}
+
+.article-overlay__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.article-overlay__close {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.article-overlay__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 22px 22px;
+  flex: 1;
+  overflow: hidden;
+}
+
+.article-overlay__list-wrapper {
+  flex: 1;
   overflow-y: auto;
+  border: 1px solid #e6e6e6;
+  border-radius: 8px;
+  background: #fafafa;
 }
 
-.article-list h2 {
-  margin-top: 0;
-  font-size: 16px;
-}
-
-.article-list ul,
-#articleItems {
+.article-overlay__list {
   list-style: none;
-  padding: 0;
   margin: 0;
-}
-
-.article-list li,
-#articleItems li {
-  padding: 6px 4px;
-  border-bottom: 1px solid #eee;
-  font-size: 14px;
-}
-
-#articleItems {
-  list-style: none;
   padding: 0;
-  margin: 0;
 }
 
-#articleItems li {
-  border-bottom: 1px solid #eee;
+.article-overlay__list li {
+  border-bottom: 1px solid #e2e2e2;
 }
 
-#articleItems li a.article-link {
+.article-overlay__list li:last-child {
+  border-bottom: none;
+}
+
+.article-overlay__list a {
   display: block;
-  padding: 6px 4px;
+  padding: 12px 14px;
   text-decoration: none;
   color: inherit;
-  border-radius: 6px;
 }
 
-#articleItems li a.article-link:hover {
-  background: #f2f2f2;
+.article-overlay__list a:hover {
+  background: rgba(0, 0, 0, 0.05);
 }
 
-
-#articleItems .code {
+.article-overlay__list .code {
   color: #555;
-  font-size: 13px;
+  font-size: 0.85em;
+}
+
+.article-overlay__empty {
+  padding: 16px;
+  text-align: center;
+  color: #666;
+  font-size: 0.95em;
+}
+
+.article-overlay__share {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.article-overlay__share h3 {
+  margin: 0;
+  font-size: 1.05rem;
 }
 
 /* --- Teilen-Link --- */
 .share-container {
   display: flex;
-  gap: 5px;
+  gap: 8px;
   align-items: center;
 }
 
 #shareInput {
   flex: 1;
-  padding: 4px;
+  padding: 8px 10px;
   border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 0.9em;
+  border-radius: 6px;
+  font-size: 0.95em;
 }
 
-#copyBtn {
-  cursor: pointer;
-  background: #eee;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 4px 8px;
-  font-size: 1em;
-  transition: background 0.2s;
-}
-
-#copyBtn:hover {
-  background: #ddd;
+#shareInput:focus-visible {
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
 }
 
 /* --- Logo oben links --- */


### PR DESCRIPTION
## Summary
- replace the in-page article list with a configurator trigger button and modal overlay markup
- restyle the configurator sidebar trigger, modal, and share inputs for a centered scrollable dialog
- initialize overlay interactions and empty-state handling while keeping sharing inside the modal

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ca659fa978832bb5ac50464ca98a63