### PR TITLE
Add help overlay and button for configurator guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,16 +19,29 @@
       <div id="stage"></div>
     </div>
     <div class="sidebar-container">
-      <button
-        id="articleListTrigger"
-        class="btn overlay-trigger"
-        type="button"
-        aria-haspopup="dialog"
-        aria-expanded="false"
-        aria-controls="articleOverlay"
-      >
-        Artikelliste
-      </button>
+      <div class="sidebar-actions">
+        <button
+          id="articleListTrigger"
+          class="btn overlay-trigger"
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-controls="articleOverlay"
+        >
+          Artikelliste
+        </button>
+        <button
+          id="helpOverlayTrigger"
+          class="btn btn--icon overlay-trigger sidebar-actions__help"
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-controls="helpOverlay"
+          aria-label="Hilfe"
+        >
+          ?
+        </button>
+      </div>
       <div class="sidebar" id="sidebar"></div>
     </div>
   </div>
@@ -56,6 +69,46 @@
           <ul id="articleItems" class="article-overlay__list"></ul>
         </div>
         <div id="articleOverlayShare" class="article-overlay__share"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="helpOverlay" class="article-overlay" aria-hidden="true">
+    <div
+      class="article-overlay__dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="helpOverlayTitle"
+    >
+      <header class="article-overlay__header">
+        <h2 id="helpOverlayTitle">So funktioniert der Konfigurator</h2>
+        <button
+          type="button"
+          class="btn btn--icon article-overlay__close"
+          data-overlay-close
+          aria-label="Hilfe schließen"
+        >
+          ✕
+        </button>
+      </header>
+      <div class="article-overlay__body help-overlay__body">
+        <p class="help-overlay__intro">
+          Stellen Sie Ihren AST31 in wenigen Schritten zusammen. Folgen Sie der empfohlenen Reihenfolge und nutzen Sie anschließend die Artikelliste.
+        </p>
+        <ol class="help-overlay__steps">
+          <li>
+            <strong>Grundtisch auswählen:</strong> Wählen Sie eine der zwei Gestellvarianten, eine der drei Breiten sowie eine der zwei Platten und ergänzen Sie bei Bedarf Seitenblenden.
+          </li>
+          <li>
+            <strong>Aufbauvariante festlegen:</strong> Entscheiden Sie sich für eine Aufbauvariante und wählen Sie die passenden Aufbauelemente.
+          </li>
+          <li>
+            <strong>Unterbau wählen:</strong> Fügen Sie Container oder ein Ablagebord hinzu.
+          </li>
+          <li>
+            <strong>Artikelliste öffnen:</strong> Klicken Sie auf die Artikelliste, um Komponenten direkt zu bestellen oder über den Share-Link eine unverbindliche Anfrage an den Schäfer Shop zu senden.
+          </li>
+        </ol>
       </div>
     </div>
   </div>

--- a/js/main.js
+++ b/js/main.js
@@ -8,9 +8,9 @@ import { initPreviewZoom } from "./zoom.js";
 
 let configXML;
 const images = {};
-function setupArticleOverlay() {
-  const overlay = document.getElementById("articleOverlay");
-  const trigger = document.getElementById("articleListTrigger");
+function setupOverlay(triggerId, overlayId) {
+  const overlay = document.getElementById(overlayId);
+  const trigger = document.getElementById(triggerId);
   if (!overlay || !trigger) return;
 
   const closeButton = overlay.querySelector("[data-overlay-close]");
@@ -32,7 +32,9 @@ function setupArticleOverlay() {
     if (!overlay.classList.contains("is-open")) return;
     overlay.classList.remove("is-open");
     overlay.setAttribute("aria-hidden", "true");
-    document.body.classList.remove("overlay-open");
+    if (!document.querySelector(".article-overlay.is-open")) {
+      document.body.classList.remove("overlay-open");
+    }
     trigger.setAttribute("aria-expanded", "false");
     if (lastFocusedElement) {
       lastFocusedElement.focus();
@@ -84,7 +86,8 @@ function loadFromURL() {
 }
 
 async function init() {
-  setupArticleOverlay();
+  setupOverlay("articleListTrigger", "articleOverlay");
+  setupOverlay("helpOverlayTrigger", "helpOverlay");
 
   // 1) Konfiguration & Artikelliste laden
   configXML = await loadConfig();

--- a/style.css
+++ b/style.css
@@ -102,12 +102,18 @@ button {
   min-height: 0;
 }
 
-#articleListTrigger {
-  margin: 0;
-  align-self: stretch;
+.sidebar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   position: sticky;
   top: 20px;
   z-index: 10;
+}
+
+#articleListTrigger {
+  margin: 0;
+  flex: 1;
   font-weight: 700;
   font-size: 0.95rem;
   text-align: center;
@@ -117,6 +123,17 @@ button {
   color: #ffffff; */
   box-shadow: 0 18px 34px -20px rgba(37, 99, 235, 0.75);
   border-radius: 12px;
+}
+
+.sidebar-actions__help {
+  font-size: 1.2rem;
+  line-height: 1;
+  color: rgba(30, 41, 59, 0.85);
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
+}
+
+.sidebar-actions__help:hover {
+  color: #1d4ed8;
 }
 
 .overlay-trigger:hover {
@@ -377,6 +394,39 @@ select:focus-visible {
   flex: 1;
   overflow: hidden;
   background: linear-gradient(135deg, rgba(250, 252, 255, 0.95), rgba(236, 239, 246, 0.95));
+}
+
+.help-overlay__body {
+  gap: 18px;
+}
+
+.help-overlay__intro {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.help-overlay__steps {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: rgba(30, 41, 59, 0.95);
+}
+
+.help-overlay__steps li {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 14px 18px;
+  box-shadow: 0 16px 30px -28px rgba(15, 23, 42, 0.55);
+}
+
+.help-overlay__steps strong {
+  display: block;
+  margin-bottom: 4px;
+  color: #1d4ed8;
+  font-size: 1.02rem;
 }
 
 .article-overlay__list-wrapper {


### PR DESCRIPTION
## Summary
- add a help icon next to the article list trigger and open an explanatory overlay
- describe the configurator workflow in a four-step guide within the new overlay
- generalize the overlay handling so both article list and help dialogs share the same logic and styling tweaks

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa8ae31a8832bb4b69a034043b6aa