### PR TITLE
Allow dragging the zoomed preview

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -189,7 +189,7 @@
         <item id="ast31-el-weissaluminium-weiss-750" x="156" y="339" scaleX="0.392" scaleY="0.4"/>
         <item id="ast31-el-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
         <item id="ast31-el-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
-
+ <offsets>
     </grundtische>
     <seitenOffsets>
       <item breite="750" side="left" x="168" y="383" scaleX="0.375" scaleY="0.375"/>

--- a/config.xml
+++ b/config.xml
@@ -169,7 +169,7 @@
            dependsOn="containerpos:rechts|links-rechts"
            offsetGroup="containerOffsets"/>
   </layers>
-
+<offsets>
     <grundtische>
         <item id="ast31-lichtgrau-buche-750" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
         <item id="ast31-lichtgrau-buche-1500" x="151" y="340" scaleX="0.502" scaleY="0.5"/>
@@ -189,7 +189,7 @@
         <item id="ast31-el-weissaluminium-weiss-750" x="156" y="339" scaleX="0.392" scaleY="0.4"/>
         <item id="ast31-el-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
         <item id="ast31-el-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
- <offsets>
+ 
     </grundtische>
     <seitenOffsets>
       <item breite="750" side="left" x="168" y="383" scaleX="0.375" scaleY="0.375"/>

--- a/config.xml
+++ b/config.xml
@@ -169,111 +169,112 @@
            dependsOn="containerpos:rechts|links-rechts"
            offsetGroup="containerOffsets"/>
   </layers>
-<offsets>
+ <offsets>
     <grundtische>
-        <item id="ast31-lichtgrau-buche-750" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-buche-1500" x="151" y="340" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-buche-2000" x="150" y="340" scaleX="0.512" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-750" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-1500" x="151" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-2000" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-750" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-1500" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-2000" x="150" y="340" scaleX="0.512" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-750" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-el-weissaluminium-buche-750" x="154" y="339" scaleX="0.468" scaleY="0.4"/>
-        <item id="ast31-el-weissaluminium-buche-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
-        <item id="ast31-el-weissaluminium-buche-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
-        <item id="ast31-el-weissaluminium-weiss-750" x="156" y="339" scaleX="0.392" scaleY="0.4"/>
-        <item id="ast31-el-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
-        <item id="ast31-el-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
- 
+        <item id="ast31-lichtgrau-buche-750" x="0" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-buche-1500" x="1" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-buche-2000" x="0" y="340" scaleX="0.512" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-750" x="0" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-1500" x="1" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-2000" x="0" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-750" x="0" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-1500" x="0" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-2000" x="0" y="340" scaleX="0.512" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-750" x="0" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-1500" x="0" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-2000" x="0" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-el-weissaluminium-buche-750" x="4" y="339" scaleX="0.468" scaleY="0.4"/>
+        <item id="ast31-el-weissaluminium-buche-1500" x="0" y="340" scaleX="0.473" scaleY="0.45"/>
+        <item id="ast31-el-weissaluminium-buche-2000" x="0" y="340" scaleX="0.48" scaleY="0.48"/>
+        <item id="ast31-el-weissaluminium-weiss-750" x="6" y="339" scaleX="0.392" scaleY="0.4"/>
+        <item id="ast31-el-weissaluminium-weiss-1500" x="0" y="340" scaleX="0.473" scaleY="0.45"/>
+        <item id="ast31-el-weissaluminium-weiss-2000" x="0" y="340" scaleX="0.48" scaleY="0.48"/>
+
     </grundtische>
     <seitenOffsets>
-      <item breite="750" side="left" x="168" y="383" scaleX="0.375" scaleY="0.375"/>
-      <item breite="750" side="right" x="338" y="383" scaleX="0.375" scaleY="0.375"/>
+      <item breite="750" side="left" x="18" y="383" scaleX="0.375" scaleY="0.375"/>
+      <item breite="750" side="right" x="188" y="383" scaleX="0.375" scaleY="0.375"/>
         
-      <item breite="1500" side="left" x="167" y="383" scaleX="0.38" scaleY="0.38"/>
-      <item breite="1500" side="right" x="553" y="384" scaleX="0.37" scaleY="0.37"/>
+      <item breite="1500" side="left" x="17" y="383" scaleX="0.38" scaleY="0.38"/>
+      <item breite="1500" side="right" x="403" y="384" scaleX="0.37" scaleY="0.37"/>
         
-      <item breite="2000" side="left" x="167" y="383" scaleX="0.38" scaleY="0.38"/>
-      <item breite="2000" side="right" x="693" y="383" scaleX="0.38" scaleY="0.38"/>
+      <item breite="2000" side="left" x="17" y="383" scaleX="0.38" scaleY="0.38"/>
+      <item breite="2000" side="right" x="543" y="383" scaleX="0.38" scaleY="0.38"/>
       <!-- usw. -->
     </seitenOffsets>
     <saeulenOffsets>
-      <item id="saeulen-niedrig-750" x="157" y="182" scaleX="0.495" scaleY="0.5"/>
-      <item id="saeulen-niedrig-1500" x="155" y="161" scaleX="0.518" scaleY="0.5"/>
-      <item id="saeulen-niedrig-2000" x="155" y="162" scaleX="0.528" scaleY="0.5"/>
+      <item id="saeulen-niedrig-750" x="7" y="182" scaleX="0.495" scaleY="0.5"/>
+      <item id="saeulen-niedrig-1500" x="5" y="161" scaleX="0.518" scaleY="0.5"/>
+      <item id="saeulen-niedrig-2000" x="5" y="162" scaleX="0.528" scaleY="0.5"/>
         
-      <item id="saeulen-hoch-750" x="157" y="40" scaleX="0.495" scaleY="0.5"/>
-      <item id="saeulen-hoch-1500" x="155" y="2" scaleX="0.518" scaleY="0.5"/>
-      <item id="saeulen-hoch-2000" x="155" y="2" scaleX="0.528" scaleY="0.5"/>
+      <item id="saeulen-hoch-750" x="7" y="40" scaleX="0.495" scaleY="0.5"/>
+      <item id="saeulen-hoch-1500" x="5" y="2" scaleX="0.518" scaleY="0.5"/>
+      <item id="saeulen-hoch-2000" x="5" y="2" scaleX="0.528" scaleY="0.5"/>
     </saeulenOffsets>
     <plattenOffsets>
-      <item id="platte1-750"  x="193" y="262" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte1-1500" x="194" y="246" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte1-2000" x="198" y="251" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte1-750"  x="43" y="262" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte1-1500" x="44" y="246" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte1-2000" x="48" y="251" scaleX="0.528" scaleY="0.5"/>
 
-      <item id="platte2-750"  x="193" y="184" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte2-1500" x="194" y="156" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte2-2000" x="198" y="161" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte2-750"  x="43" y="184" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte2-1500" x="44" y="156" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte2-2000" x="48" y="161" scaleX="0.528" scaleY="0.5"/>
 
-      <item id="platte3-750"  x="193" y="106" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte3-1500" x="194" y="66" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte3-2000" x="198" y="71" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte3-750"  x="43" y="106" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte3-1500" x="44" y="66" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte3-2000" x="48" y="71" scaleX="0.528" scaleY="0.5"/>
     </plattenOffsets>
     <laufschienenOffsets>
-      <item id="laufschiene1-750" x="167" y="58" scaleX="0.235" scaleY="0.235"/>
-      <item id="laufschiene2-750" x="159" y="53" scaleX="0.251" scaleY="0.251"/>
+      <item id="laufschiene1-750" x="17" y="58" scaleX="0.235" scaleY="0.235"/>
+      <item id="laufschiene2-750" x="9" y="53" scaleX="0.251" scaleY="0.251"/>
 
-      <item id="laufschiene1-1500" x="170" y="21" scaleX="0.251" scaleY="0.251"/>
-      <item id="laufschiene2-1500" x="161" y="15" scaleX="0.26" scaleY="0.26"/>
+      <item id="laufschiene1-1500" x="20" y="21" scaleX="0.251" scaleY="0.251"/>
+      <item id="laufschiene2-1500" x="11" y="15" scaleX="0.26" scaleY="0.26"/>
       
-      <item id="laufschiene1-2000" x="166" y="21" scaleX="0.24" scaleY="0.24"/>
-      <item id="laufschiene2-2000" x="157" y="15" scaleX="0.247" scaleY="0.247"/>
+      <item id="laufschiene1-2000" x="16" y="21" scaleX="0.24" scaleY="0.24"/>
+      <item id="laufschiene2-2000" x="7" y="15" scaleX="0.247" scaleY="0.247"/>
     </laufschienenOffsets>
     <bodenOffsets>
-      <item id="boden1-750" x="183" y="233" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden1-1500" x="183" y="216" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden1-2000" x="184" y="216" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden1-750" x="33" y="233" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden1-1500" x="33" y="216" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden1-2000" x="34" y="216" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden2-750" x="183" y="195" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden2-1500" x="183" y="175" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden2-2000" x="184" y="175" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden2-750" x="33" y="195" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden2-1500" x="33" y="175" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden2-2000" x="34" y="175" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden3-750" x="183" y="150" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden3-1500" x="183" y="125" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden3-2000" x="184" y="125" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden3-750" x="33" y="150" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden3-1500" x="33" y="125" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden3-2000" x="34" y="125" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden4-750" x="183" y="115" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden4-1500" x="183" y="82" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden4-2000" x="184" y="82" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden4-750" x="33" y="115" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden4-1500" x="33" y="82" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden4-2000" x="34" y="82" scaleX="0.456" scaleY="0.456"/>
   </bodenOffsets>
     <containerOffsets>
     <!-- 750 mm: nur links/rechts -->
-    <item breite="750" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
-    <item breite="750" side="right" x="356" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="750" side="left"  x="16" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="750" side="right" x="206" y="385" scaleX="0.25" scaleY="0.25"/>
 
     <!-- 1500 mm: links/rechts/links+rechts -->
-    <item breite="1500" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
-    <item breite="1500" side="right" x="570" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="1500" side="left"  x="16" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="1500" side="right" x="420" y="385" scaleX="0.25" scaleY="0.25"/>
 
     <!-- 2000 mm: links/rechts/links+rechts -->
-    <item breite="2000" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
-    <item breite="2000" side="right" x="710" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="2000" side="left"  x="16" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="2000" side="right" x="560" y="385" scaleX="0.25" scaleY="0.25"/>
   </containerOffsets>
     <ablagebordOffsets>
-  <item id="ablagebord-buche-750"  x="172" y="461" scaleX="0.445" scaleY="0.42"/>
-  <item id="ablagebord-buche-1500" x="168" y="460" scaleX="0.497" scaleY="0.50"/>
-  <item id="ablagebord-buche-2000" x="171" y="459" scaleX="0.5" scaleY="0.5"/>
+  <item id="ablagebord-buche-750"  x="22" y="461" scaleX="0.445" scaleY="0.42"/>
+  <item id="ablagebord-buche-1500" x="18" y="460" scaleX="0.497" scaleY="0.50"/>
+  <item id="ablagebord-buche-2000" x="21" y="459" scaleX="0.5" scaleY="0.5"/>
 
-  <item id="ablagebord-weiss-750"  x="174" y="463" scaleX="0.38" scaleY="0.5"/>
-  <item id="ablagebord-weiss-1500" x="170" y="465" scaleX="0.497" scaleY="0.55"/>
-  <item id="ablagebord-weiss-2000" x="171" y="461" scaleX="0.53" scaleY="0.55"/>
+  <item id="ablagebord-weiss-750"  x="24" y="463" scaleX="0.38" scaleY="0.5"/>
+  <item id="ablagebord-weiss-1500" x="20" y="465" scaleX="0.497" scaleY="0.55"/>
+  <item id="ablagebord-weiss-2000" x="21" y="461" scaleX="0.53" scaleY="0.55"/>
 </ablagebordOffsets>
 
   </offsets>
+
 
 </config>

--- a/config.xml
+++ b/config.xml
@@ -170,110 +170,110 @@
            offsetGroup="containerOffsets"/>
   </layers>
 
-  <offsets>
     <grundtische>
-        <item id="ast31-lichtgrau-buche-750" x="150" y="500" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-buche-1500" x="151" y="500" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-buche-2000" x="150" y="500" scaleX="0.512" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-750" x="150" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-1500" x="151" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-lichtgrau-weiss-2000" x="150" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-750" x="150" y="500" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-1500" x="150" y="500" scaleX="0.502" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-buche-2000" x="150" y="500" scaleX="0.512" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-750" x="150" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-1500" x="150" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-weissaluminium-weiss-2000" x="150" y="500" scaleX="0.5" scaleY="0.5"/>
-        <item id="ast31-el-weissaluminium-buche-750" x="154" y="499" scaleX="0.468" scaleY="0.4"/>
-        <item id="ast31-el-weissaluminium-buche-1500" x="150" y="500" scaleX="0.473" scaleY="0.45"/>
-        <item id="ast31-el-weissaluminium-buche-2000" x="150" y="500" scaleX="0.48" scaleY="0.48"/>
-        <item id="ast31-el-weissaluminium-weiss-750" x="156" y="499" scaleX="0.392" scaleY="0.4"/>
-        <item id="ast31-el-weissaluminium-weiss-1500" x="150" y="500" scaleX="0.473" scaleY="0.45"/>
-        <item id="ast31-el-weissaluminium-weiss-2000" x="150" y="500" scaleX="0.48" scaleY="0.48"/>
+        <item id="ast31-lichtgrau-buche-750" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-buche-1500" x="151" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-buche-2000" x="150" y="340" scaleX="0.512" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-750" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-1500" x="151" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-lichtgrau-weiss-2000" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-750" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-1500" x="150" y="340" scaleX="0.502" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-buche-2000" x="150" y="340" scaleX="0.512" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-750" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.5" scaleY="0.5"/>
+        <item id="ast31-el-weissaluminium-buche-750" x="154" y="339" scaleX="0.468" scaleY="0.4"/>
+        <item id="ast31-el-weissaluminium-buche-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
+        <item id="ast31-el-weissaluminium-buche-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
+        <item id="ast31-el-weissaluminium-weiss-750" x="156" y="339" scaleX="0.392" scaleY="0.4"/>
+        <item id="ast31-el-weissaluminium-weiss-1500" x="150" y="340" scaleX="0.473" scaleY="0.45"/>
+        <item id="ast31-el-weissaluminium-weiss-2000" x="150" y="340" scaleX="0.48" scaleY="0.48"/>
 
     </grundtische>
     <seitenOffsets>
-      <item breite="750" side="left" x="168" y="543" scaleX="0.375" scaleY="0.375"/>
-      <item breite="750" side="right" x="338" y="543" scaleX="0.375" scaleY="0.375"/>
+      <item breite="750" side="left" x="168" y="383" scaleX="0.375" scaleY="0.375"/>
+      <item breite="750" side="right" x="338" y="383" scaleX="0.375" scaleY="0.375"/>
         
-      <item breite="1500" side="left" x="167" y="543" scaleX="0.38" scaleY="0.38"/>
-      <item breite="1500" side="right" x="553" y="544" scaleX="0.37" scaleY="0.37"/>
+      <item breite="1500" side="left" x="167" y="383" scaleX="0.38" scaleY="0.38"/>
+      <item breite="1500" side="right" x="553" y="384" scaleX="0.37" scaleY="0.37"/>
         
-      <item breite="2000" side="left" x="167" y="543" scaleX="0.38" scaleY="0.38"/>
-      <item breite="2000" side="right" x="693" y="543" scaleX="0.38" scaleY="0.38"/>
+      <item breite="2000" side="left" x="167" y="383" scaleX="0.38" scaleY="0.38"/>
+      <item breite="2000" side="right" x="693" y="383" scaleX="0.38" scaleY="0.38"/>
       <!-- usw. -->
     </seitenOffsets>
     <saeulenOffsets>
-      <item id="saeulen-niedrig-750" x="157" y="342" scaleX="0.495" scaleY="0.5"/>
-      <item id="saeulen-niedrig-1500" x="155" y="321" scaleX="0.518" scaleY="0.5"/>
-      <item id="saeulen-niedrig-2000" x="155" y="322" scaleX="0.528" scaleY="0.5"/>
+      <item id="saeulen-niedrig-750" x="157" y="182" scaleX="0.495" scaleY="0.5"/>
+      <item id="saeulen-niedrig-1500" x="155" y="161" scaleX="0.518" scaleY="0.5"/>
+      <item id="saeulen-niedrig-2000" x="155" y="162" scaleX="0.528" scaleY="0.5"/>
         
-      <item id="saeulen-hoch-750" x="157" y="200" scaleX="0.495" scaleY="0.5"/>
-      <item id="saeulen-hoch-1500" x="155" y="162" scaleX="0.518" scaleY="0.5"/>
-      <item id="saeulen-hoch-2000" x="155" y="162" scaleX="0.528" scaleY="0.5"/>
+      <item id="saeulen-hoch-750" x="157" y="40" scaleX="0.495" scaleY="0.5"/>
+      <item id="saeulen-hoch-1500" x="155" y="2" scaleX="0.518" scaleY="0.5"/>
+      <item id="saeulen-hoch-2000" x="155" y="2" scaleX="0.528" scaleY="0.5"/>
     </saeulenOffsets>
     <plattenOffsets>
-      <item id="platte1-750"  x="193" y="422" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte1-1500" x="194" y="406" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte1-2000" x="198" y="411" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte1-750"  x="193" y="262" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte1-1500" x="194" y="246" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte1-2000" x="198" y="251" scaleX="0.528" scaleY="0.5"/>
 
-      <item id="platte2-750"  x="193" y="344" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte2-1500" x="194" y="316" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte2-2000" x="198" y="321" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte2-750"  x="193" y="184" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte2-1500" x="194" y="156" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte2-2000" x="198" y="161" scaleX="0.528" scaleY="0.5"/>
 
-      <item id="platte3-750"  x="193" y="266" scaleX="0.342" scaleY="0.32"/>
-      <item id="platte3-1500" x="194" y="226" scaleX="0.515" scaleY="0.5"/>
-      <item id="platte3-2000" x="198" y="231" scaleX="0.528" scaleY="0.5"/>
+      <item id="platte3-750"  x="193" y="106" scaleX="0.342" scaleY="0.32"/>
+      <item id="platte3-1500" x="194" y="66" scaleX="0.515" scaleY="0.5"/>
+      <item id="platte3-2000" x="198" y="71" scaleX="0.528" scaleY="0.5"/>
     </plattenOffsets>
     <laufschienenOffsets>
-      <item id="laufschiene1-750" x="167" y="218" scaleX="0.235" scaleY="0.235"/>
-      <item id="laufschiene2-750" x="159" y="213" scaleX="0.251" scaleY="0.251"/>
+      <item id="laufschiene1-750" x="167" y="58" scaleX="0.235" scaleY="0.235"/>
+      <item id="laufschiene2-750" x="159" y="53" scaleX="0.251" scaleY="0.251"/>
 
-      <item id="laufschiene1-1500" x="170" y="181" scaleX="0.251" scaleY="0.251"/>
-      <item id="laufschiene2-1500" x="161" y="175" scaleX="0.26" scaleY="0.26"/>
+      <item id="laufschiene1-1500" x="170" y="21" scaleX="0.251" scaleY="0.251"/>
+      <item id="laufschiene2-1500" x="161" y="15" scaleX="0.26" scaleY="0.26"/>
       
-      <item id="laufschiene1-2000" x="166" y="181" scaleX="0.24" scaleY="0.24"/>
-      <item id="laufschiene2-2000" x="157" y="175" scaleX="0.247" scaleY="0.247"/>
+      <item id="laufschiene1-2000" x="166" y="21" scaleX="0.24" scaleY="0.24"/>
+      <item id="laufschiene2-2000" x="157" y="15" scaleX="0.247" scaleY="0.247"/>
     </laufschienenOffsets>
     <bodenOffsets>
-      <item id="boden1-750" x="183" y="393" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden1-1500" x="183" y="376" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden1-2000" x="184" y="376" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden1-750" x="183" y="233" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden1-1500" x="183" y="216" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden1-2000" x="184" y="216" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden2-750" x="183" y="355" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden2-1500" x="183" y="335" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden2-2000" x="184" y="335" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden2-750" x="183" y="195" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden2-1500" x="183" y="175" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden2-2000" x="184" y="175" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden3-750" x="183" y="310" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden3-1500" x="183" y="285" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden3-2000" x="184" y="285" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden3-750" x="183" y="150" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden3-1500" x="183" y="125" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden3-2000" x="184" y="125" scaleX="0.456" scaleY="0.456"/>
 
-      <item id="boden4-750" x="183" y="275" scaleX="0.4" scaleY="0.4"/>
-      <item id="boden4-1500" x="183" y="242" scaleX="0.52" scaleY="0.5"/>
-      <item id="boden4-2000" x="184" y="242" scaleX="0.456" scaleY="0.456"/>
+      <item id="boden4-750" x="183" y="115" scaleX="0.4" scaleY="0.4"/>
+      <item id="boden4-1500" x="183" y="82" scaleX="0.52" scaleY="0.5"/>
+      <item id="boden4-2000" x="184" y="82" scaleX="0.456" scaleY="0.456"/>
   </bodenOffsets>
     <containerOffsets>
     <!-- 750 mm: nur links/rechts -->
-    <item breite="750" side="left"  x="166" y="545" scaleX="0.25" scaleY="0.25"/>
-    <item breite="750" side="right" x="356" y="545" scaleX="0.25" scaleY="0.25"/>
+    <item breite="750" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="750" side="right" x="356" y="385" scaleX="0.25" scaleY="0.25"/>
 
     <!-- 1500 mm: links/rechts/links+rechts -->
-    <item breite="1500" side="left"  x="166" y="545" scaleX="0.25" scaleY="0.25"/>
-    <item breite="1500" side="right" x="570" y="545" scaleX="0.25" scaleY="0.25"/>
+    <item breite="1500" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="1500" side="right" x="570" y="385" scaleX="0.25" scaleY="0.25"/>
 
     <!-- 2000 mm: links/rechts/links+rechts -->
-    <item breite="2000" side="left"  x="166" y="545" scaleX="0.25" scaleY="0.25"/>
-    <item breite="2000" side="right" x="710" y="545" scaleX="0.25" scaleY="0.25"/>
+    <item breite="2000" side="left"  x="166" y="385" scaleX="0.25" scaleY="0.25"/>
+    <item breite="2000" side="right" x="710" y="385" scaleX="0.25" scaleY="0.25"/>
   </containerOffsets>
     <ablagebordOffsets>
-  <item id="ablagebord-buche-750"  x="172" y="621" scaleX="0.445" scaleY="0.42"/>
-  <item id="ablagebord-buche-1500" x="168" y="620" scaleX="0.497" scaleY="0.50"/>
-  <item id="ablagebord-buche-2000" x="171" y="619" scaleX="0.5" scaleY="0.5"/>
+  <item id="ablagebord-buche-750"  x="172" y="461" scaleX="0.445" scaleY="0.42"/>
+  <item id="ablagebord-buche-1500" x="168" y="460" scaleX="0.497" scaleY="0.50"/>
+  <item id="ablagebord-buche-2000" x="171" y="459" scaleX="0.5" scaleY="0.5"/>
 
-  <item id="ablagebord-weiss-750"  x="174" y="623" scaleX="0.38" scaleY="0.5"/>
-  <item id="ablagebord-weiss-1500" x="170" y="625" scaleX="0.497" scaleY="0.55"/>
-  <item id="ablagebord-weiss-2000" x="171" y="621" scaleX="0.53" scaleY="0.55"/>
+  <item id="ablagebord-weiss-750"  x="174" y="463" scaleX="0.38" scaleY="0.5"/>
+  <item id="ablagebord-weiss-1500" x="170" y="465" scaleX="0.497" scaleY="0.55"/>
+  <item id="ablagebord-weiss-2000" x="171" y="461" scaleX="0.53" scaleY="0.55"/>
 </ablagebordOffsets>
 
   </offsets>
+
 </config>

--- a/js/zoom.js
+++ b/js/zoom.js
@@ -1,8 +1,10 @@
 // zoom.js
 let zoomLevel = 1;
+let pan = { x: 0, y: 0 };
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 2.5;
 const WHEEL_STEP = 0.1;
+const PAN_THRESHOLD = 1.01;
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
@@ -10,7 +12,7 @@ function applyTransform(stage, zoom, originPct = null) {
   if (originPct) {
     stage.style.transformOrigin = `${originPct.xPct}% ${originPct.yPct}%`;
   }
-  stage.style.transform = `scale(${zoom})`;
+  stage.style.transform = `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`;
 }
 
 function clientToStagePercent(stage, clientX, clientY) {
@@ -25,63 +27,209 @@ export function initPreviewZoom(previewId = "preview", stageId = "stage") {
   const stage = document.getElementById(stageId);
   if (!container || !stage) return;
 
-  // --- Wheel: Zoom um Mauszeiger ---
+  const pointerPan = {
+    active: false,
+    startX: 0,
+    startY: 0,
+    baseX: 0,
+    baseY: 0,
+    type: null,
+    touchId: null,
+  };
+
+  const isPointOverStage = (clientX, clientY) => {
+    const rect = stage.getBoundingClientRect();
+    return (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    );
+  };
+
+  const findTouchById = (touchList, id) => {
+    for (let i = 0; i < touchList.length; i += 1) {
+      const touch = touchList[i];
+      if (touch.identifier === id) return touch;
+    }
+    return null;
+  };
+
+  const clampPan = () => {
+    const containerRect = container.getBoundingClientRect();
+    const stageRect = stage.getBoundingClientRect();
+    let changed = false;
+    let nextX = pan.x;
+    let nextY = pan.y;
+
+    if (stageRect.width <= containerRect.width) {
+      if (nextX !== 0) {
+        nextX = 0;
+        changed = true;
+      }
+    } else {
+      if (stageRect.left > containerRect.left) {
+        nextX -= stageRect.left - containerRect.left;
+        changed = true;
+      }
+      if (stageRect.right < containerRect.right) {
+        nextX += containerRect.right - stageRect.right;
+        changed = true;
+      }
+    }
+
+    if (stageRect.height <= containerRect.height) {
+      if (nextY !== 0) {
+        nextY = 0;
+        changed = true;
+      }
+    } else {
+      if (stageRect.top > containerRect.top) {
+        nextY -= stageRect.top - containerRect.top;
+        changed = true;
+      }
+      if (stageRect.bottom < containerRect.bottom) {
+        nextY += containerRect.bottom - stageRect.bottom;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      pan.x = nextX;
+      pan.y = nextY;
+    }
+    return changed;
+  };
+
+  const updateTransform = (originPct = null) => {
+    applyTransform(stage, zoomLevel, originPct);
+    if (clampPan()) {
+      applyTransform(stage, zoomLevel);
+    }
+    const canPan = zoomLevel > PAN_THRESHOLD;
+    container.classList.toggle("is-grabbable", canPan);
+    if (!pointerPan.active && !canPan) {
+      container.classList.remove("is-grabbing");
+    }
+  };
+
+  const beginPan = (type, x, y, touchId = null) => {
+    pointerPan.active = true;
+    pointerPan.type = type;
+    pointerPan.touchId = touchId;
+    pointerPan.startX = x;
+    pointerPan.startY = y;
+    pointerPan.baseX = pan.x;
+    pointerPan.baseY = pan.y;
+    container.classList.add("is-grabbing");
+  };
+
+  const updatePan = (x, y) => {
+    if (!pointerPan.active) return;
+    pan.x = pointerPan.baseX + (x - pointerPan.startX);
+    pan.y = pointerPan.baseY + (y - pointerPan.startY);
+    updateTransform();
+  };
+
+  const endPan = () => {
+    if (!pointerPan.active) return;
+    pointerPan.active = false;
+    pointerPan.type = null;
+    pointerPan.touchId = null;
+    container.classList.remove("is-grabbing");
+    updateTransform();
+  };
+
   container.addEventListener(
     "wheel",
     (e) => {
-      // nur reagieren, wenn Cursor wirklich über der Stage ist
-      const path = e.composedPath ? e.composedPath() : [];
-      const onStage = path.includes(stage) || stage.contains(e.target);
-      if (!onStage) return;
+      if (!isPointOverStage(e.clientX, e.clientY)) return;
 
       e.preventDefault();
       const originPct = clientToStagePercent(stage, e.clientX, e.clientY);
 
-      const dir = Math.sign(e.deltaY); // +1 = runter
+      const dir = Math.sign(e.deltaY);
       const step = WHEEL_STEP * (e.ctrlKey ? 2 : 1);
       zoomLevel += dir > 0 ? -step : step;
       zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
 
-      applyTransform(stage, zoomLevel, originPct);
+      updateTransform(originPct);
     },
     { passive: false }
   );
 
-  // Doppelklick / -tipp = Reset
   container.addEventListener("dblclick", () => {
     zoomLevel = 1;
-    applyTransform(stage, zoomLevel, { xPct: 50, yPct: 50 });
+    pan.x = 0;
+    pan.y = 0;
+    pointerPan.active = false;
+    pointerPan.type = null;
+    pointerPan.touchId = null;
+    container.classList.remove("is-grabbing");
+    updateTransform({ xPct: 50, yPct: 50 });
   });
 
-  // --- Touch: Pinch-to-Zoom ---
   let pinchActive = false;
   let pinchStartDist = 0;
   let pinchStartZoom = 1;
 
-  const getTouchDistance = (t1, t2) =>
-    Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+  container.addEventListener("mousedown", (e) => {
+    if (e.button !== 0) return;
+    if (zoomLevel <= PAN_THRESHOLD) return;
+    if (!isPointOverStage(e.clientX, e.clientY)) return;
 
-  const getTouchCenter = (t1, t2) => ({
-    x: (t1.clientX + t2.clientX) / 2,
-    y: (t1.clientY + t2.clientY) / 2,
+    e.preventDefault();
+    beginPan("mouse", e.clientX, e.clientY);
+  });
+
+  window.addEventListener("mousemove", (e) => {
+    if (pointerPan.active && pointerPan.type === "mouse") {
+      e.preventDefault();
+      updatePan(e.clientX, e.clientY);
+    }
+  });
+
+  window.addEventListener("mouseup", () => {
+    if (pointerPan.active && pointerPan.type === "mouse") {
+      endPan();
+    }
   });
 
   container.addEventListener(
     "touchstart",
     (e) => {
       if (e.touches.length === 2) {
-        const path = e.composedPath ? e.composedPath() : [];
-        const onStage = path.includes(stage) || stage.contains(e.target);
-        if (!onStage) return;
+        const t1 = e.touches[0];
+        const t2 = e.touches[1];
+        if (
+          !isPointOverStage(t1.clientX, t1.clientY) ||
+          !isPointOverStage(t2.clientX, t2.clientY)
+        ) {
+          return;
+        }
+
+        if (pointerPan.active && pointerPan.type === "touch") {
+          endPan();
+        }
 
         pinchActive = true;
-        pinchStartDist = getTouchDistance(e.touches[0], e.touches[1]);
+        pinchStartDist = getTouchDistance(t1, t2);
         pinchStartZoom = zoomLevel;
 
-        const center = getTouchCenter(e.touches[0], e.touches[1]);
+        const center = getTouchCenter(t1, t2);
         const originPct = clientToStagePercent(stage, center.x, center.y);
-        applyTransform(stage, zoomLevel, originPct);
+        updateTransform(originPct);
+        e.preventDefault();
+        return;
+      }
 
+      if (pinchActive) return;
+
+      if (e.touches.length === 1 && zoomLevel > PAN_THRESHOLD) {
+        const touch = e.touches[0];
+        if (!isPointOverStage(touch.clientX, touch.clientY)) return;
+
+        beginPan("touch", touch.clientX, touch.clientY, touch.identifier);
         e.preventDefault();
       }
     },
@@ -92,33 +240,76 @@ export function initPreviewZoom(previewId = "preview", stageId = "stage") {
     "touchmove",
     (e) => {
       if (pinchActive && e.touches.length === 2) {
-        const dist = getTouchDistance(e.touches[0], e.touches[1]);
+        const t1 = e.touches[0];
+        const t2 = e.touches[1];
+        const dist = getTouchDistance(t1, t2);
         if (pinchStartDist > 0) {
           const ratio = dist / pinchStartDist;
           zoomLevel = clamp(pinchStartZoom * ratio, MIN_ZOOM, MAX_ZOOM);
 
-          const center = getTouchCenter(e.touches[0], e.touches[1]);
+          const center = getTouchCenter(t1, t2);
           const originPct = clientToStagePercent(stage, center.x, center.y);
-          applyTransform(stage, zoomLevel, originPct);
+          updateTransform(originPct);
         }
+        e.preventDefault();
+        return;
+      }
+
+      if (!pinchActive && pointerPan.active && pointerPan.type === "touch") {
+        const touch = findTouchById(e.touches, pointerPan.touchId);
+        if (!touch) return;
+
+        updatePan(touch.clientX, touch.clientY);
         e.preventDefault();
       }
     },
     { passive: false }
   );
 
-  container.addEventListener("touchend", () => {
-    if (pinchActive) {
-      zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
-      applyTransform(stage, zoomLevel);
-      // optional haptisches Feedback (falls vorhanden)
-      if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
-        // navigator.vibrate(5);
+  const finishPinch = () => {
+    pinchActive = false;
+    zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
+    updateTransform();
+    if (
+      typeof navigator !== "undefined" &&
+      typeof navigator.vibrate === "function"
+    ) {
+      // navigator.vibrate(5);
+    }
+  };
+
+  container.addEventListener("touchend", (e) => {
+    if (pinchActive && e.touches.length < 2) {
+      finishPinch();
+      if (e.touches.length === 1 && zoomLevel > PAN_THRESHOLD) {
+        const remaining = e.touches[0];
+        if (isPointOverStage(remaining.clientX, remaining.clientY)) {
+          beginPan(
+            "touch",
+            remaining.clientX,
+            remaining.clientY,
+            remaining.identifier
+          );
+        }
       }
     }
-    pinchActive = false;
+
+    if (!pinchActive && pointerPan.active && pointerPan.type === "touch") {
+      const stillActive = findTouchById(e.touches, pointerPan.touchId);
+      if (!stillActive) {
+        endPan();
+      }
+    }
   });
 
-  // Initial
-  applyTransform(stage, zoomLevel, { xPct: 50, yPct: 50 });
+  container.addEventListener("touchcancel", () => {
+    if (pinchActive) {
+      finishPinch();
+    }
+    if (pointerPan.active && pointerPan.type === "touch") {
+      endPan();
+    }
+  });
+
+  updateTransform({ xPct: 50, yPct: 50 });
 }

--- a/style.css
+++ b/style.css
@@ -84,6 +84,7 @@ button {
   aspect-ratio: 12 / 7;      /* entspricht z.B. 1200×700 */
   transform-origin: top left;/* Offsets bleiben stabil beim Zoom */
   will-change: transform;
+  margin: 100px 0  0 80px;
 }
 
 /* Bilder hängen jetzt unter #stage */

--- a/style.css
+++ b/style.css
@@ -56,6 +56,14 @@ button {
 
 #preview { touch-action: none; }
 
+#preview.is-grabbable {
+  cursor: grab;
+}
+
+#preview.is-grabbing {
+  cursor: grabbing;
+}
+
 
 /* --- Preview-Bereich --- */
 #preview {


### PR DESCRIPTION
## Summary
- add mouse and touch handlers to drag the zoomed preview stage
- clamp panning so the stage stays inside the preview and reset on zoom reset
- show grab/grabbing cursor feedback while the preview can be moved

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68cb0d39633c832ba23db0c775e42dac