### PR TITLE
Fix mobile zoom and pan behavior

### DIFF
--- a/js/zoom.js
+++ b/js/zoom.js
@@ -1,87 +1,266 @@
 // zoom.js
 let zoomLevel = 1;
+let pan = { x: 0, y: 0 };
 const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 2.5;
 const WHEEL_STEP = 0.1;
+const PAN_THRESHOLD = 1;
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
-
-function applyTransform(stage, zoom, originPct = null) {
-  if (originPct) {
-    stage.style.transformOrigin = `${originPct.xPct}% ${originPct.yPct}%`;
-  }
-  stage.style.transform = `scale(${zoom})`;
-}
-
-function clientToStagePercent(stage, clientX, clientY) {
-  const r = stage.getBoundingClientRect();
-  const x = ((clientX - r.left) / r.width) * 100;
-  const y = ((clientY - r.top) / r.height) * 100;
-  return { xPct: x, yPct: y };
-}
 
 export function initPreviewZoom(previewId = "preview", stageId = "stage") {
   const container = document.getElementById(previewId);
   const stage = document.getElementById(stageId);
   if (!container || !stage) return;
 
-  // --- Wheel: Zoom um Mauszeiger ---
+  stage.style.transformOrigin = "0 0";
+
+  const pointerPan = {
+    active: false,
+    startX: 0,
+    startY: 0,
+    baseX: 0,
+    baseY: 0,
+    type: null,
+    touchId: null,
+  };
+
+  const metrics = {
+    containerWidth: 0,
+    containerHeight: 0,
+    offsetX: 0,
+    offsetY: 0,
+    stageWidth: stage.offsetWidth,
+    stageHeight: stage.offsetHeight,
+  };
+
+  let pinchActive = false;
+  let pinchStartDist = 0;
+  let pinchStartZoom = 1;
+  let pinchLastCenter = null;
+
+  const updateMetrics = () => {
+    const containerRect = container.getBoundingClientRect();
+    const stageRect = stage.getBoundingClientRect();
+
+    metrics.containerWidth = containerRect.width;
+    metrics.containerHeight = containerRect.height;
+    metrics.stageWidth = stage.offsetWidth;
+    metrics.stageHeight = stage.offsetHeight;
+    metrics.offsetX = stageRect.left - containerRect.left - pan.x;
+    metrics.offsetY = stageRect.top - containerRect.top - pan.y;
+  };
+
+  const applyTransform = () => {
+    stage.style.transform = `translate3d(${pan.x}px, ${pan.y}px, 0) scale(${zoomLevel})`;
+  };
+
+  const clampPan = () => {
+    const scaledWidth = metrics.stageWidth * zoomLevel;
+    const scaledHeight = metrics.stageHeight * zoomLevel;
+
+    let nextX = pan.x;
+    if (scaledWidth <= metrics.containerWidth) {
+      const desiredLeft = (metrics.containerWidth - scaledWidth) / 2 - metrics.offsetX;
+      if (nextX !== desiredLeft) {
+        nextX = desiredLeft;
+      }
+    } else {
+      const minX = metrics.containerWidth - scaledWidth - metrics.offsetX;
+      const maxX = -metrics.offsetX;
+      nextX = clamp(nextX, minX, maxX);
+    }
+
+    let nextY = pan.y;
+    if (scaledHeight <= metrics.containerHeight) {
+      const desiredTop = -metrics.offsetY;
+      if (nextY !== desiredTop) {
+        nextY = desiredTop;
+      }
+    } else {
+      const minY = metrics.containerHeight - scaledHeight - metrics.offsetY;
+      const maxY = -metrics.offsetY;
+      nextY = clamp(nextY, minY, maxY);
+    }
+
+    const changed = nextX !== pan.x || nextY !== pan.y;
+    if (changed) {
+      pan.x = nextX;
+      pan.y = nextY;
+    }
+    return changed;
+  };
+
+  const refreshTransform = () => {
+    applyTransform();
+    updateMetrics();
+    if (clampPan()) {
+      applyTransform();
+      updateMetrics();
+    }
+
+    const canPan = zoomLevel > PAN_THRESHOLD;
+    container.classList.toggle("is-grabbable", canPan);
+    if ((!pointerPan.active && !pinchActive) || !canPan) {
+      container.classList.remove("is-grabbing");
+    }
+  };
+
+  const isPointOverStage = (clientX, clientY) => {
+    const rect = stage.getBoundingClientRect();
+    return (
+      clientX >= rect.left &&
+      clientX <= rect.right &&
+      clientY >= rect.top &&
+      clientY <= rect.bottom
+    );
+  };
+
+  const getStagePoint = (clientX, clientY) => {
+    const rect = stage.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left) / zoomLevel,
+      y: (clientY - rect.top) / zoomLevel,
+    };
+  };
+
+  const beginPan = (type, x, y, touchId = null) => {
+    pointerPan.active = true;
+    pointerPan.type = type;
+    pointerPan.touchId = touchId;
+    pointerPan.startX = x;
+    pointerPan.startY = y;
+    pointerPan.baseX = pan.x;
+    pointerPan.baseY = pan.y;
+    container.classList.add("is-grabbing");
+  };
+
+  const updatePan = (x, y) => {
+    if (!pointerPan.active) return;
+    pan.x = pointerPan.baseX + (x - pointerPan.startX);
+    pan.y = pointerPan.baseY + (y - pointerPan.startY);
+    refreshTransform();
+  };
+
+  const endPan = () => {
+    if (!pointerPan.active) return;
+    pointerPan.active = false;
+    pointerPan.type = null;
+    pointerPan.touchId = null;
+    container.classList.remove("is-grabbing");
+    refreshTransform();
+  };
+
+  const adjustZoomAtPoint = (targetZoom, clientX, clientY) => {
+    const clamped = clamp(targetZoom, MIN_ZOOM, MAX_ZOOM);
+    const prevZoom = zoomLevel;
+    if (clamped === prevZoom) {
+      refreshTransform();
+      return;
+    }
+
+    const stagePoint = getStagePoint(clientX, clientY);
+    zoomLevel = clamped;
+    pan.x += stagePoint.x * (prevZoom - zoomLevel);
+    pan.y += stagePoint.y * (prevZoom - zoomLevel);
+    refreshTransform();
+  };
+
+  const findTouchById = (touchList, id) => {
+    for (let i = 0; i < touchList.length; i += 1) {
+      if (touchList[i].identifier === id) return touchList[i];
+    }
+    return null;
+  };
+
+  const finishPinch = () => {
+    pinchActive = false;
+    pinchStartDist = 0;
+    pinchLastCenter = null;
+    zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
+    refreshTransform();
+  };
+
   container.addEventListener(
     "wheel",
     (e) => {
-      // nur reagieren, wenn Cursor wirklich über der Stage ist
-      const path = e.composedPath ? e.composedPath() : [];
-      const onStage = path.includes(stage) || stage.contains(e.target);
-      if (!onStage) return;
-
+      if (!isPointOverStage(e.clientX, e.clientY)) return;
       e.preventDefault();
-      const originPct = clientToStagePercent(stage, e.clientX, e.clientY);
-
-      const dir = Math.sign(e.deltaY); // +1 = runter
+      const direction = Math.sign(e.deltaY);
       const step = WHEEL_STEP * (e.ctrlKey ? 2 : 1);
-      zoomLevel += dir > 0 ? -step : step;
-      zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
-
-      applyTransform(stage, zoomLevel, originPct);
+      const nextZoom = zoomLevel + (direction > 0 ? -step : step);
+      adjustZoomAtPoint(nextZoom, e.clientX, e.clientY);
     },
     { passive: false }
   );
 
-  // Doppelklick / -tipp = Reset
   container.addEventListener("dblclick", () => {
     zoomLevel = 1;
-    applyTransform(stage, zoomLevel, { xPct: 50, yPct: 50 });
+    pan.x = 0;
+    pan.y = 0;
+    pointerPan.active = false;
+    pointerPan.type = null;
+    pointerPan.touchId = null;
+    pinchActive = false;
+    pinchStartDist = 0;
+    pinchLastCenter = null;
+    container.classList.remove("is-grabbing");
+    refreshTransform();
   });
 
-  // --- Touch: Pinch-to-Zoom ---
-  let pinchActive = false;
-  let pinchStartDist = 0;
-  let pinchStartZoom = 1;
+  container.addEventListener("mousedown", (e) => {
+    if (e.button !== 0) return;
+    if (zoomLevel <= PAN_THRESHOLD) return;
+    if (!isPointOverStage(e.clientX, e.clientY)) return;
+    e.preventDefault();
+    beginPan("mouse", e.clientX, e.clientY);
+  });
 
-  const getTouchDistance = (t1, t2) =>
-    Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+  window.addEventListener("mousemove", (e) => {
+    if (pointerPan.active && pointerPan.type === "mouse") {
+      e.preventDefault();
+      updatePan(e.clientX, e.clientY);
+    }
+  });
 
-  const getTouchCenter = (t1, t2) => ({
-    x: (t1.clientX + t2.clientX) / 2,
-    y: (t1.clientY + t2.clientY) / 2,
+  window.addEventListener("mouseup", () => {
+    if (pointerPan.active && pointerPan.type === "mouse") {
+      endPan();
+    }
   });
 
   container.addEventListener(
     "touchstart",
     (e) => {
       if (e.touches.length === 2) {
-        const path = e.composedPath ? e.composedPath() : [];
-        const onStage = path.includes(stage) || stage.contains(e.target);
-        if (!onStage) return;
+        const [t1, t2] = [e.touches[0], e.touches[1]];
+        if (
+          !isPointOverStage(t1.clientX, t1.clientY) &&
+          !isPointOverStage(t2.clientX, t2.clientY)
+        ) {
+          return;
+        }
+
+        const center = getTouchCenter(t1, t2);
+
+        if (pointerPan.active && pointerPan.type === "touch") {
+          endPan();
+        }
 
         pinchActive = true;
-        pinchStartDist = getTouchDistance(e.touches[0], e.touches[1]);
+        pinchStartDist = getTouchDistance(t1, t2);
         pinchStartZoom = zoomLevel;
+        pinchLastCenter = center;
+        e.preventDefault();
+        return;
+      }
 
-        const center = getTouchCenter(e.touches[0], e.touches[1]);
-        const originPct = clientToStagePercent(stage, center.x, center.y);
-        applyTransform(stage, zoomLevel, originPct);
+      if (pinchActive) return;
 
+      if (e.touches.length === 1 && zoomLevel > PAN_THRESHOLD) {
+        const touch = e.touches[0];
+        if (!isPointOverStage(touch.clientX, touch.clientY)) return;
+        beginPan("touch", touch.clientX, touch.clientY, touch.identifier);
         e.preventDefault();
       }
     },
@@ -92,33 +271,83 @@ export function initPreviewZoom(previewId = "preview", stageId = "stage") {
     "touchmove",
     (e) => {
       if (pinchActive && e.touches.length === 2) {
-        const dist = getTouchDistance(e.touches[0], e.touches[1]);
-        if (pinchStartDist > 0) {
-          const ratio = dist / pinchStartDist;
-          zoomLevel = clamp(pinchStartZoom * ratio, MIN_ZOOM, MAX_ZOOM);
+        const [t1, t2] = [e.touches[0], e.touches[1]];
+        const center = getTouchCenter(t1, t2);
+        const stagePoint = getStagePoint(center.x, center.y);
 
-          const center = getTouchCenter(e.touches[0], e.touches[1]);
-          const originPct = clientToStagePercent(stage, center.x, center.y);
-          applyTransform(stage, zoomLevel, originPct);
+        if (pinchLastCenter) {
+          pan.x += center.x - pinchLastCenter.x;
+          pan.y += center.y - pinchLastCenter.y;
         }
+        pinchLastCenter = center;
+
+        if (pinchStartDist > 0) {
+          const ratio = getTouchDistance(t1, t2) / pinchStartDist;
+          const nextZoom = pinchStartZoom * ratio;
+          const prevZoom = zoomLevel;
+          zoomLevel = clamp(nextZoom, MIN_ZOOM, MAX_ZOOM);
+          pan.x += stagePoint.x * (prevZoom - zoomLevel);
+          pan.y += stagePoint.y * (prevZoom - zoomLevel);
+        }
+        refreshTransform();
+        e.preventDefault();
+        return;
+      }
+
+      if (!pinchActive && pointerPan.active && pointerPan.type === "touch") {
+        const touch = findTouchById(e.touches, pointerPan.touchId);
+        if (!touch) return;
+        updatePan(touch.clientX, touch.clientY);
         e.preventDefault();
       }
     },
     { passive: false }
   );
 
-  container.addEventListener("touchend", () => {
-    if (pinchActive) {
-      zoomLevel = clamp(zoomLevel, MIN_ZOOM, MAX_ZOOM);
-      applyTransform(stage, zoomLevel);
-      // optional haptisches Feedback (falls vorhanden)
-      if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
-        // navigator.vibrate(5);
+  container.addEventListener("touchend", (e) => {
+    if (pinchActive && e.touches.length < 2) {
+      finishPinch();
+      if (e.touches.length === 1 && zoomLevel > PAN_THRESHOLD) {
+        const remaining = e.touches[0];
+        if (isPointOverStage(remaining.clientX, remaining.clientY)) {
+          beginPan("touch", remaining.clientX, remaining.clientY, remaining.identifier);
+        }
       }
     }
-    pinchActive = false;
+
+    if (!pinchActive && pointerPan.active && pointerPan.type === "touch") {
+      const stillActive = findTouchById(e.touches, pointerPan.touchId);
+      if (!stillActive) {
+        endPan();
+      }
+    }
   });
 
-  // Initial
-  applyTransform(stage, zoomLevel, { xPct: 50, yPct: 50 });
+  container.addEventListener("touchcancel", () => {
+    if (pinchActive) {
+      finishPinch();
+    }
+    if (pointerPan.active && pointerPan.type === "touch") {
+      endPan();
+    }
+  });
+
+  window.addEventListener("resize", () => {
+    refreshTransform();
+  });
+
+  refreshTransform();
+}
+
+function getTouchDistance(t1, t2) {
+  const dx = t1.clientX - t2.clientX;
+  const dy = t1.clientY - t2.clientY;
+  return Math.hypot(dx, dy);
+}
+
+function getTouchCenter(t1, t2) {
+  return {
+    x: (t1.clientX + t2.clientX) / 2,
+    y: (t1.clientY + t2.clientY) / 2,
+  };
 }

--- a/style.css
+++ b/style.css
@@ -56,6 +56,14 @@ button {
 
 #preview { touch-action: none; }
 
+#preview.is-grabbable {
+  cursor: grab;
+}
+
+#preview.is-grabbing {
+  cursor: grabbing;
+}
+
 
 /* --- Preview-Bereich --- */
 #preview {
@@ -75,6 +83,7 @@ button {
   width: min(100%, 1200px);  /* Basisbreite, responsiv begrenzt */
   aspect-ratio: 12 / 7;      /* entspricht z.B. 1200×700 */
   transform-origin: top left;/* Offsets bleiben stabil beim Zoom */
+  touch-action: none;
   will-change: transform;
 }
 


### PR DESCRIPTION
## Summary
- rework preview transform handling to clamp panning using layout metrics and keep focus points stable while zooming
- improve touch gesture handling so pinch and single-finger panning work reliably on iOS devices
- disable native gestures on the stage element to avoid conflicts during touch interactions

## Testing
- not run (static project)

------
https://chatgpt.com/codex/tasks/task_e_68cb0d39633c832ba23db0c775e42dac