### PR TITLE
Replace key selects with slider UI

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -3,25 +3,32 @@ import { applyAst31Logic, applyBodenPlattenLogic, applyContainerLogic, applyLauf
 import { placeImage } from "./imageManager.js";
 import { renderArticleList } from "./articles.js";
 import { updateURL } from "./share.js";
+import { syncSliderControls } from "./uiBuilder.js";
 
 export function updatePreview(configXML, images) {
   const values = {};
   document.querySelectorAll(".sidebar select").forEach(sel => values[sel.id] = sel.value);
 
   // --- Spezial-Logik für AST31-EL ---
-  	applyAst31Logic(values);
+  applyAst31Logic(values);
 
   // --- Logik für Böden + Platten ---
-  	applyBodenPlattenLogic(values);
+  applyBodenPlattenLogic(values);
 
   // --- Logik für Container ---
-  	applyContainerLogic(values);
+  applyContainerLogic(values);
   // --- Logik für Laufschienen ---
-	applyLaufschienenLogic(values);
+  applyLaufschienenLogic(values);
   // --- Logik für Ablagebords ---
-	applyAblagebordLogic(values);
+  applyAblagebordLogic(values);
 
-  
+  syncSliderControls();
+
+  document.querySelectorAll(".sidebar select").forEach(sel => {
+    values[sel.id] = sel.value;
+  });
+
+
   // --- Layer abarbeiten ---
   configXML.querySelectorAll("layers > layer").forEach(layerNode => {
     const id = layerNode.getAttribute("id");

--- a/js/uiBuilder.js
+++ b/js/uiBuilder.js
@@ -1,5 +1,175 @@
 // uiBuilder.js
-import { updatePreview } from "./preview.js";
+
+const sliderFieldIds = new Set([
+  "breite",
+  "bodenanzahl",
+  "plattenanzahl",
+  "laufschienenanzahl"
+]);
+
+const sliderControls = new Map();
+
+function getOptions(control) {
+  return Array.from(control.select.options);
+}
+
+function findNearestEnabledIndex(control, requestedIndex) {
+  const options = getOptions(control);
+  if (!options.length) return 0;
+
+  let index = Math.min(Math.max(requestedIndex, 0), options.length - 1);
+  if (!options[index]?.disabled) {
+    return index;
+  }
+
+  const lastIndex = control.lastIndex ?? 0;
+  const direction = index > lastIndex ? 1 : index < lastIndex ? -1 : 0;
+  const searchDirections = direction === 0 ? [1, -1] : [direction, -direction];
+
+  for (const dir of searchDirections) {
+    let i = index;
+    while (i >= 0 && i < options.length) {
+      i += dir;
+      if (i < 0 || i >= options.length) break;
+      if (!options[i].disabled) {
+        return i;
+      }
+    }
+  }
+
+  if (!options[lastIndex]?.disabled) {
+    return lastIndex;
+  }
+
+  const fallback = options.findIndex(opt => !opt.disabled);
+  return fallback === -1 ? index : fallback;
+}
+
+function updateSliderControl(control) {
+  const options = getOptions(control);
+  const maxIndex = Math.max(options.length - 1, 0);
+  control.slider.max = String(maxIndex);
+
+  let index = options.findIndex(opt => opt.value === control.select.value);
+  if (index === -1) {
+    index = findNearestEnabledIndex(control, control.lastIndex ?? 0);
+    if (options[index]) {
+      control.select.value = options[index].value;
+    }
+  }
+
+  control.lastIndex = index;
+  control.slider.value = String(index);
+
+  const option = options[index];
+  const valueText = option ? option.textContent : "";
+  control.valueDisplay.textContent = valueText;
+  control.slider.setAttribute("aria-valuetext", valueText);
+
+  const progress = maxIndex === 0 ? 0 : (index / maxIndex) * 100;
+  control.slider.style.setProperty("--slider-progress", `${progress}%`);
+
+  const disableSlider = control.select.disabled || options.every(opt => opt.disabled);
+  control.slider.disabled = disableSlider;
+  control.wrapper.classList.toggle("is-disabled", disableSlider);
+
+  control.ticks.forEach((tick, idx) => {
+    const opt = options[idx];
+    const isDisabledTick = disableSlider || opt?.disabled;
+    tick.classList.toggle("is-disabled", Boolean(isDisabledTick));
+    tick.classList.toggle("is-active", idx === index);
+  });
+}
+
+export function syncSliderControls() {
+  sliderControls.forEach(updateSliderControl);
+}
+
+function createSliderControl(id, select) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "slider-field";
+
+  const track = document.createElement("div");
+  track.className = "slider-field__track";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.id = `${id}-slider`;
+  slider.className = "slider-field__input";
+  slider.min = "0";
+  slider.step = "1";
+  slider.value = "0";
+
+  const ticks = document.createElement("div");
+  ticks.className = "slider-field__ticks";
+
+  const tickElements = [];
+  const options = Array.from(select.options);
+  const divisor = Math.max(options.length - 1, 1);
+  options.forEach((_, idx) => {
+    const tick = document.createElement("span");
+    tick.className = "slider-field__tick";
+    const percent = options.length === 1 ? 0 : (idx / divisor) * 100;
+    tick.style.left = `${percent}%`;
+    ticks.appendChild(tick);
+    tickElements.push(tick);
+  });
+
+  track.appendChild(slider);
+  track.appendChild(ticks);
+  wrapper.appendChild(track);
+
+  const valueDisplay = document.createElement("div");
+  valueDisplay.className = "slider-field__value";
+  valueDisplay.setAttribute("aria-live", "polite");
+  wrapper.appendChild(valueDisplay);
+
+  select.classList.add("slider-field__select");
+  select.setAttribute("aria-hidden", "true");
+  select.tabIndex = -1;
+  wrapper.appendChild(select);
+
+  const control = {
+    id,
+    select,
+    slider,
+    wrapper,
+    valueDisplay,
+    ticks: tickElements,
+    lastIndex: 0
+  };
+
+  sliderControls.set(id, control);
+
+  const handleSliderInput = event => {
+    if (slider.disabled) return;
+    const rawIndex = Number(event.target.value);
+    const index = findNearestEnabledIndex(control, rawIndex);
+    const optionsList = getOptions(control);
+    const option = optionsList[index];
+    control.slider.value = String(index);
+    if (!option) {
+      updateSliderControl(control);
+      return;
+    }
+
+    if (control.select.value !== option.value) {
+      control.select.value = option.value;
+      control.lastIndex = index;
+      control.select.dispatchEvent(new Event("change", { bubbles: true }));
+    } else {
+      control.lastIndex = index;
+      updateSliderControl(control);
+    }
+  };
+
+  slider.addEventListener("input", handleSliderInput);
+  slider.addEventListener("change", handleSliderInput);
+
+  updateSliderControl(control);
+
+  return wrapper;
+}
 
 /**
  * Baut die Sidebar anhand des configXML.
@@ -7,6 +177,7 @@ import { updatePreview } from "./preview.js";
  */
 export function buildSidebar(configXML, container, onChange) {
   container.innerHTML = "";
+  sliderControls.clear();
 
   configXML.querySelectorAll("groups > group").forEach(groupNode => {
     const group = document.createElement("div");
@@ -69,9 +240,30 @@ export function buildSidebar(configXML, container, onChange) {
           sel.appendChild(opt);
         });
 
-        sel.addEventListener("change", onChange);
-        content.appendChild(labelEl);
-        content.appendChild(sel);
+        const isSliderField = sliderFieldIds.has(id);
+
+        const handleChange = () => {
+          if (isSliderField) {
+            const control = sliderControls.get(id);
+            if (control) {
+              updateSliderControl(control);
+            }
+          }
+          onChange();
+        };
+
+        sel.addEventListener("change", handleChange);
+
+        if (isSliderField) {
+          labelEl.htmlFor = `${id}-slider`;
+          content.appendChild(labelEl);
+          const sliderWrapper = createSliderControl(id, sel);
+          content.appendChild(sliderWrapper);
+        } else {
+          labelEl.htmlFor = id;
+          content.appendChild(labelEl);
+          content.appendChild(sel);
+        }
       });
 
       sec.appendChild(secHeader);

--- a/style.css
+++ b/style.css
@@ -311,6 +311,181 @@ select:focus-visible {
   outline: none;
 }
 
+.slider-field {
+  margin: 6px 0 18px 0;
+}
+
+.section .content .slider-field:last-of-type {
+  margin-bottom: 0;
+}
+
+.slider-field__track {
+  position: relative;
+  padding: 12px 0 4px;
+}
+
+.slider-field__input {
+  --slider-progress: 0%;
+  width: 100%;
+  height: 30px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  cursor: pointer;
+}
+
+.slider-field__input::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(
+    90deg,
+    #2563eb 0%,
+    #2563eb var(--slider-progress),
+    rgba(148, 163, 184, 0.35) var(--slider-progress),
+    rgba(148, 163, 184, 0.35) 100%
+  );
+}
+
+.slider-field__input::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.slider-field__input::-moz-range-progress {
+  height: 6px;
+  border-radius: 999px;
+  background: #2563eb;
+}
+
+.slider-field__input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  border: 3px solid #eef2ff;
+  box-shadow: 0 10px 18px -10px rgba(37, 99, 235, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  margin-top: -7px;
+}
+
+.slider-field__input::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #2563eb;
+  border: 3px solid #eef2ff;
+  box-shadow: 0 10px 18px -10px rgba(37, 99, 235, 0.6);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slider-field__input:hover::-webkit-slider-thumb,
+.slider-field__input:hover::-moz-range-thumb {
+  transform: scale(1.05);
+  box-shadow: 0 12px 22px -12px rgba(37, 99, 235, 0.65);
+}
+
+.slider-field__input:focus-visible::-webkit-slider-thumb,
+.slider-field__input:focus-visible::-moz-range-thumb {
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.28);
+}
+
+.slider-field__input::-moz-focus-outer {
+  border: 0;
+}
+
+.slider-field__input:disabled {
+  cursor: not-allowed;
+}
+
+.slider-field__input:disabled::-webkit-slider-runnable-track {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.slider-field__input:disabled::-moz-range-track {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.slider-field__input:disabled::-moz-range-progress {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.slider-field__input:disabled::-webkit-slider-thumb,
+.slider-field__input:disabled::-moz-range-thumb {
+  background: rgba(148, 163, 184, 0.7);
+  border-color: #e2e8f0;
+  box-shadow: none;
+  transform: none;
+}
+
+.slider-field__ticks {
+  position: absolute;
+  inset: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.slider-field__tick {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: #e2e8f0;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+}
+
+.slider-field__tick.is-active {
+  background: #2563eb;
+  border-color: #1d4ed8;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.18);
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
+.slider-field__tick.is-disabled {
+  background: rgba(226, 232, 240, 0.9);
+  border-color: rgba(148, 163, 184, 0.4);
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.slider-field.is-disabled .slider-field__tick.is-active {
+  background: rgba(148, 163, 184, 0.6);
+  border-color: rgba(148, 163, 184, 0.45);
+  box-shadow: none;
+  transform: translate(-50%, -50%);
+}
+
+.slider-field__value {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 0.85rem;
+  min-height: 24px;
+}
+
+.slider-field.is-disabled .slider-field__value {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(71, 85, 105, 0.7);
+}
+
+.slider-field__select {
+  display: none;
+}
+
 .section .content label {
   display: block;
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- render the width, shelves, perforated panels, and guide rail selectors as slider controls while keeping hidden selects for existing logic
- keep the slider UI in sync with config logic updates when recomputing the preview
- style the sliders with tick marks, focus states, and a value badge to highlight the chosen option

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc0134a178832b8f5a0b59b5b7dc3d