### PR TITLE
Fix responsive sidebar overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,6 +7,12 @@ body {
   overflow: hidden;
 }
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body.overlay-open {
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- apply border-box sizing globally so responsive panels account for their padding and no longer overflow the viewport

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd21cbd324832bacb5f1ed37567604