### PR TITLE
Enable scrolling within sidebar container

### DIFF
--- a/style.css
+++ b/style.css
@@ -135,6 +135,7 @@ button {
   backdrop-filter: blur(6px);
   box-shadow: -18px 0 36px -30px rgba(15, 23, 42, 0.35);
   min-height: 0;
+  overflow-y: auto;
 }
 
 .sidebar-actions {
@@ -179,7 +180,6 @@ button {
 .sidebar {
   flex: 1;
   padding: 2px 0px;
-  overflow-y: auto;
   min-height: 0;
   /* background: #ffffff; */
   /* border: 1px solid black; */
@@ -914,6 +914,7 @@ select:focus-visible {
     backdrop-filter: blur(8px);
     gap: 16px;
     flex: none;
+    overflow: visible;
   }
 
   .sidebar-actions {


### PR DESCRIPTION
## Summary
- allow the sidebar container to handle its own vertical overflow so actions and content scroll together on large viewports
- remove the nested sidebar scroll area and ensure the responsive layout keeps its previous overflow behaviour under 1024px

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da852aee74832b998baa500462e089