### PR TITLE
Warn before automatic configuration adjustments

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,89 @@ import { initPreviewZoom } from "./zoom.js";
 
 let configXML;
 const images = {};
+let lastKnownValues = {};
+
+function getSidebarSelects() {
+  return document.querySelectorAll(".sidebar select");
+}
+
+function collectSidebarValues() {
+  const values = {};
+  getSidebarSelects().forEach(sel => {
+    values[sel.id] = sel.value;
+  });
+  return values;
+}
+
+function updatePreviousValueDatasets() {
+  getSidebarSelects().forEach(sel => {
+    sel.dataset.previousValue = sel.value;
+  });
+}
+
+function getOptionText(select, value) {
+  if (!select) return value;
+  const option = Array.from(select.options).find(opt => opt.value === value);
+  return option ? option.textContent.trim() : value;
+}
+
+function applySidebarValues(values) {
+  Object.entries(values).forEach(([id, value]) => {
+    const select = document.getElementById(id);
+    if (select) {
+      select.value = value;
+    }
+  });
+}
+
+function handleSidebarChange({ id, previousValue }) {
+  if (!configXML) return;
+
+  const beforeValues = { ...lastKnownValues };
+  updatePreview(configXML, images);
+
+  const newValues = collectSidebarValues();
+
+  const hadValuesBefore = Object.keys(beforeValues).length > 0;
+  if (hadValuesBefore) {
+    const adjustments = Object.keys(newValues)
+      .filter(key => key !== id && beforeValues[key] !== undefined && beforeValues[key] !== newValues[key])
+      .map(key => ({
+        id: key,
+        oldValue: beforeValues[key],
+        newValue: newValues[key]
+      }));
+
+    if (adjustments.length > 0) {
+      const adjustmentText = adjustments.map(({ id: fieldId, oldValue, newValue }) => {
+        const select = document.getElementById(fieldId);
+        const label = select?.dataset.label || fieldId;
+        const oldLabel = getOptionText(select, oldValue);
+        const newLabel = getOptionText(select, newValue);
+        return `- ${label}: ${oldLabel} → ${newLabel}`;
+      }).join("\n");
+
+      const message = `Warnung: Die aktuelle Änderung führt zu einer ungültigen Konfiguration.\n` +
+        `Daher würden folgende Werte angepasst:\n\n${adjustmentText}\n\n` +
+        "Möchten Sie die Änderung trotzdem übernehmen?";
+
+      if (!window.confirm(message)) {
+        applySidebarValues(beforeValues);
+        const select = document.getElementById(id);
+        if (select) {
+          select.value = previousValue;
+        }
+        updatePreview(configXML, images);
+        lastKnownValues = collectSidebarValues();
+        updatePreviousValueDatasets();
+        return;
+      }
+    }
+  }
+
+  lastKnownValues = newValues;
+  updatePreviousValueDatasets();
+}
 function setupOverlay(triggerId, overlayId) {
   const overlay = document.getElementById(overlayId);
   const trigger = document.getElementById(triggerId);
@@ -96,7 +179,7 @@ async function init() {
 
   // 2) Sidebar bauen (setzt Defaults aus config.xml)
   const sidebarEl = document.getElementById("sidebar");
-  buildSidebar(configXML, sidebarEl, () => updatePreview(configXML, images));
+  buildSidebar(configXML, sidebarEl, handleSidebarChange);
 
   // 3) Layer-Images vorbereiten – in #stage einhängen (Fallback: #preview)
   const stage = document.getElementById("stage") || document.getElementById("preview");
@@ -117,6 +200,8 @@ async function init() {
 
   // 6) Erste Darstellung
   updatePreview(configXML, images);
+  lastKnownValues = collectSidebarValues();
+  updatePreviousValueDatasets();
 }
 
 init();

--- a/js/uiBuilder.js
+++ b/js/uiBuilder.js
@@ -233,6 +233,7 @@ export function buildSidebar(configXML, container, onChange) {
 
         const sel = document.createElement("select");
         sel.id = id;
+        sel.dataset.label = label;
 
         configXML.querySelectorAll(`options > ${optGroup} > wert`).forEach(optNode => {
           const opt = document.createElement("option");
@@ -244,16 +245,22 @@ export function buildSidebar(configXML, container, onChange) {
           sel.appendChild(opt);
         });
 
+        sel.dataset.previousValue = sel.value;
+
         const isSliderField = sliderFieldIds.has(id);
 
         const handleChange = () => {
+          const previousValue = sel.dataset.previousValue ?? sel.value;
           if (isSliderField) {
             const control = sliderControls.get(id);
             if (control) {
               updateSliderControl(control);
             }
           }
-          onChange();
+          if (typeof onChange === "function") {
+            onChange({ id, select: sel, previousValue });
+          }
+          sel.dataset.previousValue = sel.value;
         };
 
         sel.addEventListener("change", handleChange);


### PR DESCRIPTION
## Summary
- track the last confirmed sidebar values and detect when a change would force other fields to update
- prompt the user before applying such invalid combinations and restore the previous configuration when cancelled
- annotate sidebar controls with metadata needed to show descriptive warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8b1dfbd4832bba2beef4b23818b4